### PR TITLE
0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,31 +25,22 @@ Documentation is hosted at [https://zentity.io/#/docs](https://zentity.io/#/docs
 
 Once you have installed Elasticsearch, you can install zentity from a remote URL or a local file.
 
-### Install from remote URL
-
 1. Browse the **[releases](https://zentity.io/#/releases)**.
 2. Find a release that matches your version of Elasticsearch. Copy the name of the .zip file.
 3. Install the plugin using the `elasticsearch-plugin` script that comes with Elasticsearch.
 
 Example:
 
-`elasticsearch-plugin install https://zentity.io/releases/zentity-0.2.0-beta.1-elasticsearch-6.2.3.zip`
+`elasticsearch-plugin install https://zentity.io/releases/zentity-0.2.1-beta.1-elasticsearch-6.2.3.zip`
 
-
-### Install from local file
-
-1. Browse the **[releases](https://zentity.io/#/releases)**.
-2. Find a release that matches your version of Elasticsearch. Download the .zip file.
-4. Install the plugin using the `elasticsearch-plugin` script that comes with Elasticsearch.
-
-Example:
-
-`elasticsearch-plugin install file:///path/to/zentity-0.2.0-beta.1-elasticsearch-6.2.3.zip`
-
+Read the [installation](https://zentity.io/#/docs/installation) docs for more details.
 
 ### Next steps
 
-Read the **[documentation](https://zentity.io/#/docs/basic-usage)** to learn how to create and manage
+Read the **[documentation](https://zentity.io/#/docs/basic-usage)** to learn about [entity models](https://zentity.io/#/docs/entity-models),
+how to [manage entity models](https://zentity.io/#/docs/rest-apis/models-api), and how to [resolve entities](https://zentity.io/#/docs/rest-apis/resolution-api).
+
+how to create and manage
 entity models and how to resolve entities.
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <zentity.author>Dave Moore</zentity.author>
         <zentity.classname>org.elasticsearch.plugin.zentity.ZentityPlugin</zentity.classname>
         <zentity.website>https://zentity.io</zentity.website>
-        <zentity.version>0.2.0-beta.1</zentity.version>
+        <zentity.version>0.2.1-beta.1</zentity.version>
         <!-- dependency versions -->
         <elasticsearch.version>6.2.3</elasticsearch.version>
         <jackson.version>2.9.4</jackson.version>

--- a/src/main/java/io/zentity/model/IndexField.java
+++ b/src/main/java/io/zentity/model/IndexField.java
@@ -13,9 +13,12 @@ public class IndexField {
             Arrays.asList("attribute")
     );
     private static final Pattern REGEX_EMPTY = Pattern.compile("^\\s*$");
+    private static final Pattern REGEX_PERIOD = Pattern.compile("\\.");
 
     private final String index;
     private final String name;
+    private String path;
+    private String pathParent;
     private String attribute;
     private String matcher;
 
@@ -23,6 +26,7 @@ public class IndexField {
         validateName(name);
         this.index = index;
         this.name = name;
+        this.nameToPaths(name);
         this.deserialize(json);
     }
 
@@ -30,6 +34,7 @@ public class IndexField {
         validateName(name);
         this.index = index;
         this.name = name;
+        this.nameToPaths(name);
         this.deserialize(json);
     }
 
@@ -39,6 +44,14 @@ public class IndexField {
 
     public String name() {
         return this.name;
+    }
+
+    public String path() {
+        return this.path;
+    }
+
+    public String pathParent() {
+        return this.pathParent;
     }
 
     public String attribute() {
@@ -57,6 +70,13 @@ public class IndexField {
     public void matcher(JsonNode value) throws ValidationException {
         validateMatcher(value);
         this.matcher = value.textValue();
+    }
+
+    private void nameToPaths(String name) {
+        String[] parts = REGEX_PERIOD.split(name);
+        this.path = "/" + String.join("/", parts);
+        if (parts.length > 1)
+            this.pathParent = "/" + String.join("/", Arrays.copyOf(parts, parts.length - 1));
     }
 
     private void validateName(String value) throws ValidationException {

--- a/src/test/java/io/zentity/resolution/JobIT.java
+++ b/src/test/java/io/zentity/resolution/JobIT.java
@@ -15,7 +15,7 @@ public class JobIT extends AbstractITCase {
 
     private final Map<String, String> params = Collections.emptyMap();
 
-    private final StringEntity testJobPayload = new StringEntity("{\n" +
+    private final StringEntity TEST_PAYLOAD_JOB = new StringEntity("{\n" +
             "  \"attributes\": {\n" +
             "    \"attribute_a\": \"a_00\"\n" +
             "  },\n" +
@@ -25,7 +25,7 @@ public class JobIT extends AbstractITCase {
             "  }\n" +
             "}", ContentType.APPLICATION_JSON);
 
-    private final StringEntity testJobMaxHopsAndDocsPayload = new StringEntity("{\n" +
+    private final StringEntity TEST_PAYLOAD_JOB_MAX_HOPS_AND_DOCS = new StringEntity("{\n" +
             "  \"attributes\": {\n" +
             "    \"attribute_d\": \"d_00\"\n" +
             "  },\n" +
@@ -34,87 +34,94 @@ public class JobIT extends AbstractITCase {
             "  }\n" +
             "}", ContentType.APPLICATION_JSON);
 
-    private final StringEntity testJobDataTypesBooleanTrue = new StringEntity("{\n" +
+    private final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_BOOLEAN_TRUE = new StringEntity("{\n" +
             "  \"attributes\": { \"attribute_type_boolean\": true },\n" +
             "  \"scope\": {\n" +
             "    \"indices\": [ \".zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_boolean\" ]\n" +
             "  }\n" +
             "}", ContentType.APPLICATION_JSON);
 
-    private final StringEntity testJobDataTypesBooleanFalse = new StringEntity("{\n" +
+    private final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_BOOLEAN_FALSE = new StringEntity("{\n" +
             "  \"attributes\": { \"attribute_type_boolean\": false },\n" +
             "  \"scope\": {\n" +
             "    \"indices\": [ \".zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_boolean\" ]\n" +
             "  }\n" +
             "}", ContentType.APPLICATION_JSON);
 
-    private final StringEntity testJobDataTypesDoublePositive = new StringEntity("{\n" +
+    private final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_DOUBLE_POSITIVE = new StringEntity("{\n" +
             "  \"attributes\": { \"attribute_type_double\": 3.141592653589793 },\n" +
             "  \"scope\": {\n" +
             "    \"indices\": [ \".zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_double\" ]\n" +
             "  }\n" +
             "}", ContentType.APPLICATION_JSON);
 
-    private final StringEntity testJobDataTypesDoubleNegative = new StringEntity("{\n" +
+    private final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_DOUBLE_NEGATIVE = new StringEntity("{\n" +
             "  \"attributes\": { \"attribute_type_double\": -3.141592653589793 },\n" +
             "  \"scope\": {\n" +
             "    \"indices\": [ \".zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_double\" ]\n" +
             "  }\n" +
             "}", ContentType.APPLICATION_JSON);
 
-    private final StringEntity testJobDataTypesFloatPositive = new StringEntity("{\n" +
+    private final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_FLOAT_POSITIVE = new StringEntity("{\n" +
             "  \"attributes\": { \"attribute_type_float\": 1.0 },\n" +
             "  \"scope\": {\n" +
             "    \"indices\": [ \".zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_float\" ]\n" +
             "  }\n" +
             "}", ContentType.APPLICATION_JSON);
 
-    private final StringEntity testJobDataTypesFloatNegative = new StringEntity("{\n" +
+    private final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_FLOAT_NEGATIVE = new StringEntity("{\n" +
             "  \"attributes\": { \"attribute_type_float\": -1.0 },\n" +
             "  \"scope\": {\n" +
             "    \"indices\": [ \".zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_float\" ]\n" +
             "  }\n" +
             "}", ContentType.APPLICATION_JSON);
 
-    private final StringEntity testJobDataTypesIntegerPositive = new StringEntity("{\n" +
+    private final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_INTEGER_POSITIVE = new StringEntity("{\n" +
             "  \"attributes\": { \"attribute_type_integer\": 1 },\n" +
             "  \"scope\": {\n" +
             "    \"indices\": [ \".zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_integer\" ]\n" +
             "  }\n" +
             "}", ContentType.APPLICATION_JSON);
 
-    private final StringEntity testJobDataTypesIntegerNegative = new StringEntity("{\n" +
+    private final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_INTEGER_NEGATIVE = new StringEntity("{\n" +
             "  \"attributes\": { \"attribute_type_integer\": -1 },\n" +
             "  \"scope\": {\n" +
             "    \"indices\": [ \".zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_integer\" ]\n" +
             "  }\n" +
             "}", ContentType.APPLICATION_JSON);
 
-    private final StringEntity testJobDataTypesLongPositive = new StringEntity("{\n" +
+    private final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_LONG_POSITIVE = new StringEntity("{\n" +
             "  \"attributes\": { \"attribute_type_long\": 922337203685477 },\n" +
             "  \"scope\": {\n" +
             "    \"indices\": [ \".zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_long\" ]\n" +
             "  }\n" +
             "}", ContentType.APPLICATION_JSON);
 
-    private final StringEntity testJobDataTypesLongNegative = new StringEntity("{\n" +
+    private final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_LONG_NEGATIVE = new StringEntity("{\n" +
             "  \"attributes\": { \"attribute_type_long\": -922337203685477 },\n" +
             "  \"scope\": {\n" +
             "    \"indices\": [ \".zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_long\" ]\n" +
             "  }\n" +
             "}", ContentType.APPLICATION_JSON);
 
-    private final StringEntity testJobDataTypesStringA = new StringEntity("{\n" +
+    private final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_STRING_A = new StringEntity("{\n" +
             "  \"attributes\": { \"attribute_type_string\": \"a\" },\n" +
             "  \"scope\": {\n" +
             "    \"indices\": [ \".zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_string\" ]\n" +
             "  }\n" +
             "}", ContentType.APPLICATION_JSON);
 
-    private final StringEntity testJobDataTypesStringB = new StringEntity("{\n" +
+    private final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_STRING_B = new StringEntity("{\n" +
             "  \"attributes\": { \"attribute_type_string\": \"b\" },\n" +
             "  \"scope\": {\n" +
             "    \"indices\": [ \".zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_string\" ]\n" +
+            "  }\n" +
+            "}", ContentType.APPLICATION_JSON);
+
+    private final StringEntity TEST_PAYLOAD_JOB_OBJECT = new StringEntity("{\n" +
+            "  \"attributes\": { \"attribute_object\": \"a\" },\n" +
+            "  \"scope\": {\n" +
+            "    \"indices\": [ \".zentity_test_index_a\" ], \"resolvers\": [ \"resolver_object\" ]\n" +
             "  }\n" +
             "}", ContentType.APPLICATION_JSON);
 
@@ -169,7 +176,7 @@ public class JobIT extends AbstractITCase {
         try {
             prepareTestResources();
             String endpoint = "_zentity/resolution/zentity_test_entity_a";
-            Response response = client.performRequest("POST", endpoint, params, testJobPayload);
+            Response response = client.performRequest("POST", endpoint, params, TEST_PAYLOAD_JOB);
             JsonNode json = mapper.readTree(response.getEntity().getContent());
             assertEquals(json.get("hits").get("total").asInt(), 6);
 
@@ -191,7 +198,7 @@ public class JobIT extends AbstractITCase {
         try {
             prepareTestResources();
             String endpoint = "_zentity/resolution/zentity_test_entity_a?max_hops=2&max_docs_per_query=2";
-            Response response = client.performRequest("POST", endpoint, params, testJobMaxHopsAndDocsPayload);
+            Response response = client.performRequest("POST", endpoint, params, TEST_PAYLOAD_JOB_MAX_HOPS_AND_DOCS);
             JsonNode json = mapper.readTree(response.getEntity().getContent());
             assertEquals(json.get("hits").get("total").asInt(), 20);
 
@@ -243,76 +250,99 @@ public class JobIT extends AbstractITCase {
             docsExpectedB.add("a9,0");
 
             // Boolean true
-            Response r1 = client.performRequest("POST", endpoint, params, testJobDataTypesBooleanTrue);
+            Response r1 = client.performRequest("POST", endpoint, params, TEST_PAYLOAD_JOB_DATA_TYPES_BOOLEAN_TRUE);
             JsonNode j1 = mapper.readTree(r1.getEntity().getContent());
             assertEquals(j1.get("hits").get("total").asInt(), 5);
             assertEquals(docsExpectedA, getActual(j1));
 
             // Boolean false
-            Response r2 = client.performRequest("POST", endpoint, params, testJobDataTypesBooleanFalse);
+            Response r2 = client.performRequest("POST", endpoint, params, TEST_PAYLOAD_JOB_DATA_TYPES_BOOLEAN_FALSE);
             JsonNode j2 = mapper.readTree(r2.getEntity().getContent());
             assertEquals(j2.get("hits").get("total").asInt(), 5);
             assertEquals(docsExpectedB, getActual(j2));
 
             // Double positive
-            Response r3 = client.performRequest("POST", endpoint, params, testJobDataTypesDoublePositive);
+            Response r3 = client.performRequest("POST", endpoint, params, TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_DOUBLE_POSITIVE);
             JsonNode j3 = mapper.readTree(r3.getEntity().getContent());
             assertEquals(j3.get("hits").get("total").asInt(), 5);
             assertEquals(docsExpectedA, getActual(j3));
 
             // Double negative
-            Response r4 = client.performRequest("POST", endpoint, params, testJobDataTypesDoubleNegative);
+            Response r4 = client.performRequest("POST", endpoint, params, TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_DOUBLE_NEGATIVE);
             JsonNode j4 = mapper.readTree(r4.getEntity().getContent());
             assertEquals(j4.get("hits").get("total").asInt(), 5);
             assertEquals(docsExpectedB, getActual(j4));
 
             // Float positive
-            Response r5 = client.performRequest("POST", endpoint, params, testJobDataTypesFloatPositive);
+            Response r5 = client.performRequest("POST", endpoint, params, TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_FLOAT_POSITIVE);
             JsonNode j5 = mapper.readTree(r5.getEntity().getContent());
             assertEquals(j5.get("hits").get("total").asInt(), 5);
             assertEquals(docsExpectedA, getActual(j5));
 
             // Float negative
-            Response r6 = client.performRequest("POST", endpoint, params, testJobDataTypesFloatNegative);
+            Response r6 = client.performRequest("POST", endpoint, params, TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_FLOAT_NEGATIVE);
             JsonNode j6 = mapper.readTree(r6.getEntity().getContent());
             assertEquals(j6.get("hits").get("total").asInt(), 5);
             assertEquals(docsExpectedB, getActual(j6));
 
             // Integer positive
-            Response r7 = client.performRequest("POST", endpoint, params, testJobDataTypesIntegerPositive);
+            Response r7 = client.performRequest("POST", endpoint, params, TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_INTEGER_POSITIVE);
             JsonNode j7 = mapper.readTree(r7.getEntity().getContent());
             assertEquals(j7.get("hits").get("total").asInt(), 5);
             assertEquals(docsExpectedA, getActual(j7));
 
             // Integer negative
-            Response r8 = client.performRequest("POST", endpoint, params, testJobDataTypesIntegerNegative);
+            Response r8 = client.performRequest("POST", endpoint, params, TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_INTEGER_NEGATIVE);
             JsonNode j8 = mapper.readTree(r8.getEntity().getContent());
             assertEquals(j8.get("hits").get("total").asInt(), 5);
             assertEquals(docsExpectedB, getActual(j8));
 
             // Long positive
-            Response r9 = client.performRequest("POST", endpoint, params, testJobDataTypesLongPositive);
+            Response r9 = client.performRequest("POST", endpoint, params, TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_LONG_POSITIVE);
             JsonNode j9 = mapper.readTree(r9.getEntity().getContent());
             assertEquals(j9.get("hits").get("total").asInt(), 5);
             assertEquals(docsExpectedA, getActual(j9));
 
             // Long negative
-            Response r10 = client.performRequest("POST", endpoint, params, testJobDataTypesLongNegative);
+            Response r10 = client.performRequest("POST", endpoint, params, TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_LONG_NEGATIVE);
             JsonNode j10 = mapper.readTree(r10.getEntity().getContent());
             assertEquals(j10.get("hits").get("total").asInt(), 5);
             assertEquals(docsExpectedB, getActual(j10));
 
             // String A
-            Response r11 = client.performRequest("POST", endpoint, params, testJobDataTypesStringA);
+            Response r11 = client.performRequest("POST", endpoint, params, TEST_PAYLOAD_JOB_DATA_TYPES_STRING_A);
             JsonNode j11 = mapper.readTree(r11.getEntity().getContent());
             assertEquals(j11.get("hits").get("total").asInt(), 5);
             assertEquals(docsExpectedA, getActual(j11));
 
             // String B
-            Response r12 = client.performRequest("POST", endpoint, params, testJobDataTypesStringB);
+            Response r12 = client.performRequest("POST", endpoint, params, TEST_PAYLOAD_JOB_DATA_TYPES_STRING_B);
             JsonNode j12 = mapper.readTree(r12.getEntity().getContent());
             assertEquals(j12.get("hits").get("total").asInt(), 5);
             assertEquals(docsExpectedB, getActual(j12));
+
+        } finally {
+            destroyTestResources();
+        }
+    }
+
+    public void testJobObject() throws Exception {
+        try {
+            prepareTestResources();
+            String endpoint = "_zentity/resolution/zentity_test_entity_a";
+
+            Set<String> docsExpectedA = new HashSet<>();
+            docsExpectedA.add("a0,0");
+            docsExpectedA.add("a2,0");
+            docsExpectedA.add("a4,0");
+            docsExpectedA.add("a6,0");
+            docsExpectedA.add("a8,0");
+
+            // Boolean true
+            Response r1 = client.performRequest("POST", endpoint, params, TEST_PAYLOAD_JOB_OBJECT);
+            JsonNode j1 = mapper.readTree(r1.getEntity().getContent());
+            assertEquals(j1.get("hits").get("total").asInt(), 5);
+            assertEquals(docsExpectedA, getActual(j1));
 
         } finally {
             destroyTestResources();

--- a/src/test/resources/TestData.txt
+++ b/src/test/resources/TestData.txt
@@ -1,80 +1,80 @@
 { "index" : { "_index": ".zentity_test_index_a", "_type": "doc", "_id": "a0" }}
-{"field_a": "a_00", "field_b": "b_00", "field_c": "c_00", "field_d": "d_00", "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
+{"field_a": "a_00", "field_b": "b_00", "field_c": "c_00", "field_d": "d_00", "object": {"a": {"b": {"c": "a"}}}, "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
 { "index" : { "_index": ".zentity_test_index_a", "_type": "doc", "_id": "a1" }}
-{"field_a": "a 02", "field_b": "b_03", "field_c": "c_03", "field_d": "d_00", "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
+{"field_a": "a 02", "field_b": "b_03", "field_c": "c_03", "field_d": "d_00", "object": {"a": {"b": {"c": "b"}}}, "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
 { "index" : { "_index": ".zentity_test_index_a", "_type": "doc", "_id": "a2" }}
-{"field_a": "a_10", "field_b": "b_10", "field_c": "c_10", "field_d": "d_00", "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
+{"field_a": "a_10", "field_b": "b_10", "field_c": "c_10", "field_d": "d_00", "object": {"a": {"b": {"c": "a"}}}, "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
 { "index" : { "_index": ".zentity_test_index_a", "_type": "doc", "_id": "a3" }}
-{"field_a": "a_10", "field_b": "b_10", "field_c": "c_11", "field_d": "d_01", "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
+{"field_a": "a_10", "field_b": "b_10", "field_c": "c_11", "field_d": "d_01", "object": {"a": {"b": {"c": "b"}}}, "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
 { "index" : { "_index": ".zentity_test_index_a", "_type": "doc", "_id": "a4" }}
-{"field_a": "a_10", "field_b": "b_11", "field_c": "c_10", "field_d": "d_01", "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
+{"field_a": "a_10", "field_b": "b_11", "field_c": "c_10", "field_d": "d_01", "object": {"a": {"b": {"c": "a"}}}, "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
 { "index" : { "_index": ".zentity_test_index_a", "_type": "doc", "_id": "a5" }}
-{"field_a": "a_10", "field_b": "b_11", "field_c": "c_11", "field_d": "d_01", "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
+{"field_a": "a_10", "field_b": "b_11", "field_c": "c_11", "field_d": "d_01", "object": {"a": {"b": {"c": "b"}}}, "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
 { "index" : { "_index": ".zentity_test_index_a", "_type": "doc", "_id": "a6" }}
-{"field_a": "a_11", "field_b": "b_10", "field_c": "c_10", "field_d": "d_02", "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
+{"field_a": "a_11", "field_b": "b_10", "field_c": "c_10", "field_d": "d_02", "object": {"a": {"b": {"c": "a"}}}, "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
 { "index" : { "_index": ".zentity_test_index_a", "_type": "doc", "_id": "a7" }}
-{"field_a": "a_11", "field_b": "b_10", "field_c": "c_11", "field_d": "d_02", "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
+{"field_a": "a_11", "field_b": "b_10", "field_c": "c_11", "field_d": "d_02", "object": {"a": {"b": {"c": "b"}}}, "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
 { "index" : { "_index": ".zentity_test_index_a", "_type": "doc", "_id": "a8" }}
-{"field_a": "a_11", "field_b": "b_11", "field_c": "c_10", "field_d": "d_03", "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
+{"field_a": "a_11", "field_b": "b_11", "field_c": "c_10", "field_d": "d_03", "object": {"a": {"b": {"c": "a"}}}, "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
 { "index" : { "_index": ".zentity_test_index_a", "_type": "doc", "_id": "a9" }}
-{"field_a": "a_11", "field_b": "b_11", "field_c": "c_11", "field_d": "d_03", "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
+{"field_a": "a_11", "field_b": "b_11", "field_c": "c_11", "field_d": "d_03", "object": {"a": {"b": {"c": "b"}}}, "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
 { "index" : { "_index": ".zentity_test_index_b", "_type": "doc", "_id": "b0" }}
-{"field_a": "a_00", "field_b": "b 01", "field_c": "c_01", "field_d": "d_00", "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
+{"field_a": "a_00", "field_b": "b 01", "field_c": "c_01", "field_d": "d_00", "object": {"a": {"b": {"c": "a"}}}, "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
 { "index" : { "_index": ".zentity_test_index_b", "_type": "doc", "_id": "b1" }}
-{"field_a": "a_04", "field_b": "b_03", "field_c": "c 03", "field_d": "d_00", "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
+{"field_a": "a_04", "field_b": "b_03", "field_c": "c 03", "field_d": "d_00", "object": {"a": {"b": {"c": "b"}}}, "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
 { "index" : { "_index": ".zentity_test_index_b", "_type": "doc", "_id": "b2" }}
-{"field_a": "a_10", "field_b": "b_10", "field_c": "c_10", "field_d": "d_00", "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
+{"field_a": "a_10", "field_b": "b_10", "field_c": "c_10", "field_d": "d_00", "object": {"a": {"b": {"c": "a"}}}, "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
 { "index" : { "_index": ".zentity_test_index_b", "_type": "doc", "_id": "b3" }}
-{"field_a": "a_10", "field_b": "b_10", "field_c": "c_11", "field_d": "d_01", "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
+{"field_a": "a_10", "field_b": "b_10", "field_c": "c_11", "field_d": "d_01", "object": {"a": {"b": {"c": "b"}}}, "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
 { "index" : { "_index": ".zentity_test_index_b", "_type": "doc", "_id": "b4" }}
-{"field_a": "a_10", "field_b": "b_11", "field_c": "c_10", "field_d": "d_01", "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
+{"field_a": "a_10", "field_b": "b_11", "field_c": "c_10", "field_d": "d_01", "object": {"a": {"b": {"c": "a"}}}, "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
 { "index" : { "_index": ".zentity_test_index_b", "_type": "doc", "_id": "b5" }}
-{"field_a": "a_10", "field_b": "b_11", "field_c": "c_11", "field_d": "d_01", "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
+{"field_a": "a_10", "field_b": "b_11", "field_c": "c_11", "field_d": "d_01", "object": {"a": {"b": {"c": "b"}}}, "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
 { "index" : { "_index": ".zentity_test_index_b", "_type": "doc", "_id": "b6" }}
-{"field_a": "a_11", "field_b": "b_10", "field_c": "c_10", "field_d": "d_02", "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
+{"field_a": "a_11", "field_b": "b_10", "field_c": "c_10", "field_d": "d_02", "object": {"a": {"b": {"c": "a"}}}, "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
 { "index" : { "_index": ".zentity_test_index_b", "_type": "doc", "_id": "b7" }}
-{"field_a": "a_11", "field_b": "b_10", "field_c": "c_11", "field_d": "d_02", "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
+{"field_a": "a_11", "field_b": "b_10", "field_c": "c_11", "field_d": "d_02", "object": {"a": {"b": {"c": "b"}}}, "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
 { "index" : { "_index": ".zentity_test_index_b", "_type": "doc", "_id": "b8" }}
-{"field_a": "a_11", "field_b": "b_11", "field_c": "c_10", "field_d": "d_03", "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
+{"field_a": "a_11", "field_b": "b_11", "field_c": "c_10", "field_d": "d_03", "object": {"a": {"b": {"c": "a"}}}, "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
 { "index" : { "_index": ".zentity_test_index_b", "_type": "doc", "_id": "b9" }}
-{"field_a": "a_11", "field_b": "b_11", "field_c": "c_11", "field_d": "d_03", "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
+{"field_a": "a_11", "field_b": "b_11", "field_c": "c_11", "field_d": "d_03", "object": {"a": {"b": {"c": "b"}}}, "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
 { "index" : { "_index": ".zentity_test_index_c", "_type": "doc", "_id": "c0" }}
-{"field_a": "a_02", "field_b": "b_01", "field_c": "c 01", "field_d": "d_00", "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
+{"field_a": "a_02", "field_b": "b_01", "field_c": "c 01", "field_d": "d_00", "object": {"a": {"b": {"c": "a"}}}, "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
 { "index" : { "_index": ".zentity_test_index_c", "_type": "doc", "_id": "c1" }}
-{"field_a": "a 04", "field_b": "b_05", "field_c": "c_05", "field_d": "d_00", "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
+{"field_a": "a 04", "field_b": "b_05", "field_c": "c_05", "field_d": "d_00", "object": {"a": {"b": {"c": "b"}}}, "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
 { "index" : { "_index": ".zentity_test_index_c", "_type": "doc", "_id": "c2" }}
-{"field_a": "a_10", "field_b": "b_10", "field_c": "c_10", "field_d": "d_00", "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
+{"field_a": "a_10", "field_b": "b_10", "field_c": "c_10", "field_d": "d_00", "object": {"a": {"b": {"c": "a"}}}, "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
 { "index" : { "_index": ".zentity_test_index_c", "_type": "doc", "_id": "c3" }}
-{"field_a": "a_10", "field_b": "b_10", "field_c": "c_11", "field_d": "d_01", "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
+{"field_a": "a_10", "field_b": "b_10", "field_c": "c_11", "field_d": "d_01", "object": {"a": {"b": {"c": "b"}}}, "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
 { "index" : { "_index": ".zentity_test_index_c", "_type": "doc", "_id": "c4" }}
-{"field_a": "a_10", "field_b": "b_11", "field_c": "c_10", "field_d": "d_01", "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
+{"field_a": "a_10", "field_b": "b_11", "field_c": "c_10", "field_d": "d_01", "object": {"a": {"b": {"c": "a"}}}, "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
 { "index" : { "_index": ".zentity_test_index_c", "_type": "doc", "_id": "c5" }}
-{"field_a": "a_10", "field_b": "b_11", "field_c": "c_11", "field_d": "d_01", "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
+{"field_a": "a_10", "field_b": "b_11", "field_c": "c_11", "field_d": "d_01", "object": {"a": {"b": {"c": "b"}}}, "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
 { "index" : { "_index": ".zentity_test_index_c", "_type": "doc", "_id": "c6" }}
-{"field_a": "a_11", "field_b": "b_10", "field_c": "c_10", "field_d": "d_02", "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
+{"field_a": "a_11", "field_b": "b_10", "field_c": "c_10", "field_d": "d_02", "object": {"a": {"b": {"c": "a"}}}, "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
 { "index" : { "_index": ".zentity_test_index_c", "_type": "doc", "_id": "c7" }}
-{"field_a": "a_11", "field_b": "b_10", "field_c": "c_11", "field_d": "d_02", "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
+{"field_a": "a_11", "field_b": "b_10", "field_c": "c_11", "field_d": "d_02", "object": {"a": {"b": {"c": "b"}}}, "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
 { "index" : { "_index": ".zentity_test_index_c", "_type": "doc", "_id": "c8" }}
-{"field_a": "a_11", "field_b": "b_11", "field_c": "c_10", "field_d": "d_03", "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
+{"field_a": "a_11", "field_b": "b_11", "field_c": "c_10", "field_d": "d_03", "object": {"a": {"b": {"c": "a"}}}, "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
 { "index" : { "_index": ".zentity_test_index_c", "_type": "doc", "_id": "c9" }}
-{"field_a": "a_11", "field_b": "b_11", "field_c": "c_11", "field_d": "d_03", "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
+{"field_a": "a_11", "field_b": "b_11", "field_c": "c_11", "field_d": "d_03", "object": {"a": {"b": {"c": "b"}}}, "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
 { "index" : { "_index": ".zentity_test_index_d", "_type": "doc", "_id": "d0" }}
-{"field_a": "a_02", "field_b": "b_01", "field_c": "c 01", "field_d": "d_00", "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
+{"field_a": "a_02", "field_b": "b_01", "field_c": "c 01", "field_d": "d_00", "object": {"a": {"b": {"c": "a"}}}, "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
 { "index" : { "_index": ".zentity_test_index_d", "_type": "doc", "_id": "d1" }}
-{"field_a": "a 04", "field_b": "b_05", "field_c": "c_05", "field_d": "d_00", "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
+{"field_a": "a 04", "field_b": "b_05", "field_c": "c_05", "field_d": "d_00", "object": {"a": {"b": {"c": "b"}}}, "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
 { "index" : { "_index": ".zentity_test_index_d", "_type": "doc", "_id": "d2" }}
-{"field_a": "a_10", "field_b": "b_10", "field_c": "c_10", "field_d": "d_00", "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
+{"field_a": "a_10", "field_b": "b_10", "field_c": "c_10", "field_d": "d_00", "object": {"a": {"b": {"c": "a"}}}, "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
 { "index" : { "_index": ".zentity_test_index_d", "_type": "doc", "_id": "d3" }}
-{"field_a": "a_10", "field_b": "b_10", "field_c": "c_11", "field_d": "d_01", "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
+{"field_a": "a_10", "field_b": "b_10", "field_c": "c_11", "field_d": "d_01", "object": {"a": {"b": {"c": "b"}}}, "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
 { "index" : { "_index": ".zentity_test_index_d", "_type": "doc", "_id": "d4" }}
-{"field_a": "a_10", "field_b": "b_11", "field_c": "c_10", "field_d": "d_01", "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
+{"field_a": "a_10", "field_b": "b_11", "field_c": "c_10", "field_d": "d_01", "object": {"a": {"b": {"c": "a"}}}, "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
 { "index" : { "_index": ".zentity_test_index_d", "_type": "doc", "_id": "d5" }}
-{"field_a": "a_10", "field_b": "b_11", "field_c": "c_11", "field_d": "d_01", "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
+{"field_a": "a_10", "field_b": "b_11", "field_c": "c_11", "field_d": "d_01", "object": {"a": {"b": {"c": "b"}}}, "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
 { "index" : { "_index": ".zentity_test_index_d", "_type": "doc", "_id": "d6" }}
-{"field_a": "a_11", "field_b": "b_10", "field_c": "c_10", "field_d": "d_02", "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
+{"field_a": "a_11", "field_b": "b_10", "field_c": "c_10", "field_d": "d_02", "object": {"a": {"b": {"c": "a"}}}, "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
 { "index" : { "_index": ".zentity_test_index_d", "_type": "doc", "_id": "d7" }}
-{"field_a": "a_11", "field_b": "b_10", "field_c": "c_11", "field_d": "d_02", "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
+{"field_a": "a_11", "field_b": "b_10", "field_c": "c_11", "field_d": "d_02", "object": {"a": {"b": {"c": "b"}}}, "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
 { "index" : { "_index": ".zentity_test_index_d", "_type": "doc", "_id": "d8" }}
-{"field_a": "a_11", "field_b": "b_11", "field_c": "c_10", "field_d": "d_03", "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
+{"field_a": "a_11", "field_b": "b_11", "field_c": "c_10", "field_d": "d_03", "object": {"a": {"b": {"c": "a"}}}, "type_boolean": true, "type_double": 3.141592653589793, "type_float": 1.0, "type_integer": 1, "type_long": 922337203685477, "type_string": "a"}
 { "index" : { "_index": ".zentity_test_index_d", "_type": "doc", "_id": "d9" }}
-{"field_a": "a_11", "field_b": "b_11", "field_c": "c_11", "field_d": "d_03", "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}
+{"field_a": "a_11", "field_b": "b_11", "field_c": "c_11", "field_d": "d_03", "object": {"a": {"b": {"c": "b"}}}, "type_boolean": false, "type_double": -3.141592653589793, "type_float": -1.0, "type_integer": -1, "type_long": -922337203685477, "type_string": "b"}

--- a/src/test/resources/TestEntityModel.json
+++ b/src/test/resources/TestEntityModel.json
@@ -23,6 +23,9 @@
     },
     "attribute_type_string": {
       "type": "string"
+    },
+    "attribute_object": {
+      "type": "string"
     }
   },
   "resolvers": {
@@ -70,6 +73,11 @@
     "resolver_type_string": {
       "attributes": [
         "attribute_type_string"
+      ]
+    },
+    "resolver_object": {
+      "attributes": [
+        "attribute_object"
       ]
     }
   },
@@ -148,6 +156,10 @@
         "type_string": {
           "attribute": "attribute_type_string",
           "matcher": "matcher_b"
+        },
+        "object.a.b.c.keyword": {
+          "attribute": "attribute_object",
+          "matcher": "matcher_b"
         }
       }
     },
@@ -207,6 +219,10 @@
         },
         "type_string": {
           "attribute": "attribute_type_string",
+          "matcher": "matcher_b"
+        },
+        "object.a.b.c.keyword": {
+          "attribute": "attribute_object",
           "matcher": "matcher_b"
         }
       }
@@ -268,6 +284,10 @@
         "type_string": {
           "attribute": "attribute_type_string",
           "matcher": "matcher_b"
+        },
+        "object.a.b.c.keyword": {
+          "attribute": "attribute_object",
+          "matcher": "matcher_b"
         }
       }
     },
@@ -327,6 +347,10 @@
         },
         "type_string": {
           "attribute": "attribute_type_string",
+          "matcher": "matcher_b"
+        },
+        "object.a.b.c.keyword": {
+          "attribute": "attribute_object",
           "matcher": "matcher_b"
         }
       }

--- a/src/test/resources/TestIndex.json
+++ b/src/test/resources/TestIndex.json
@@ -12,7 +12,9 @@
       },
       "analyzer": {
         "strip_punct": {
-          "filter": [ "strip_punct" ],
+          "filter": [
+            "strip_punct"
+          ],
           "tokenizer": "keyword"
         }
       }
@@ -86,6 +88,26 @@
         },
         "type_string": {
           "type": "keyword"
+        },
+        "object": {
+          "properties": {
+            "a": {
+              "properties": {
+                "b": {
+                  "properties": {
+                    "c": {
+                      "type": "text",
+                      "fields": {
+                        "keyword": {
+                          "type": "keyword"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Releasing 0.2.1, which ensures that index fields having multiple nested properties (e.g. "user.details.email.keyword") are appropriately queried and returned with the "_attributes" field of the response. Fixed two NullPointerExceptions which had the potential to appear whenever the attribute or matcher of an index field did not exist in the model.