### PR TITLE
1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,28 +18,28 @@ zentity aims to be:
 
 ## Documentation
 
-Documentation is hosted at [https://zentity.io/#/docs](https://zentity.io/#/docs)
+Documentation is hosted at [https://zentity.io/docs](https://zentity.io/docs)
 
 
 ## Quick start
 
 Once you have installed Elasticsearch, you can install zentity from a remote URL or a local file.
 
-1. Browse the **[releases](https://zentity.io/#/releases)**.
+1. Browse the [releases](https://zentity.io/releases).
 2. Find a release that matches your version of Elasticsearch. Copy the name of the .zip file.
 3. Install the plugin using the `elasticsearch-plugin` script that comes with Elasticsearch.
 
 Example:
 
-`elasticsearch-plugin install https://zentity.io/releases/zentity-0.5.0-beta.2-elasticsearch-6.2.4.zip`
+`elasticsearch-plugin install https://zentity.io/releases/zentity-1.0.0-elasticsearch-6.2.4.zip`
 
-Read the [installation](https://zentity.io/#/docs/installation) docs for more details.
+Read the [installation](https://zentity.io/docs/installation) docs for more details.
 
 
 ### Next steps
 
-Read the **[documentation](https://zentity.io/#/docs/basic-usage)** to learn about [entity models](https://zentity.io/#/docs/entity-models),
-how to [manage entity models](https://zentity.io/#/docs/rest-apis/models-api), and how to [resolve entities](https://zentity.io/#/docs/rest-apis/resolution-api).
+Read the [documentation](https://zentity.io/docs/basic-usage) to learn about [entity models](https://zentity.io/docs/entity-models),
+how to [manage entity models](https://zentity.io/docs/rest-apis/models-api), and how to [resolve entities](https://zentity.io/docs/rest-apis/resolution-api).
 
 how to create and manage
 entity models and how to resolve entities.

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <zentity.author>Dave Moore</zentity.author>
         <zentity.classname>org.elasticsearch.plugin.zentity.ZentityPlugin</zentity.classname>
         <zentity.website>https://zentity.io</zentity.website>
-        <zentity.version>0.5.0-beta.2</zentity.version>
+        <zentity.version>1.0.0</zentity.version>
         <!-- dependency versions -->
         <elasticsearch.version>6.2.4</elasticsearch.version>
         <jackson.version>2.9.4</jackson.version>

--- a/src/main/java/io/zentity/common/Json.java
+++ b/src/main/java/io/zentity/common/Json.java
@@ -1,5 +1,6 @@
 package io.zentity.common;
 
+import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
@@ -7,5 +8,22 @@ public class Json {
 
     public static final ObjectMapper MAPPER = new ObjectMapper();
     public static final ObjectMapper ORDERED_MAPPER = new ObjectMapper().configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+    private static final JsonStringEncoder STRING_ENCODER = new JsonStringEncoder();
+
+    public static String quoteString(String value) {
+        return jsonStringFormat(value);
+    }
+
+    private static String jsonStringEscape(String value) {
+        return new String(STRING_ENCODER.quoteAsString(value));
+    }
+
+    private static String jsonStringQuote(String value) {
+        return "\"" + value + "\"";
+    }
+
+    private static String jsonStringFormat(String value) {
+        return jsonStringQuote(jsonStringEscape(value));
+    }
 
 }

--- a/src/main/java/org/elasticsearch/plugin/zentity/ResolutionAction.java
+++ b/src/main/java/org/elasticsearch/plugin/zentity/ResolutionAction.java
@@ -65,10 +65,8 @@ public class ResolutionAction extends BaseRestHandler {
                     String model = getResponse.getSourceAsString();
                     input = new Input(body, new Model(model));
                 }
-                if (input.attributes().isEmpty())
-                    throw new ValidationException("'attributes' is missing.");
                 if (input.model() == null)
-                    throw new ValidationException("'model' is missing.");
+                    throw new ValidationException("An entity model was not given for this request.");
 
                 // Prepare the entity resolution job.
                 Job job = new Job(client);

--- a/src/main/java/org/elasticsearch/plugin/zentity/SetupAction.java
+++ b/src/main/java/org/elasticsearch/plugin/zentity/SetupAction.java
@@ -1,0 +1,115 @@
+package org.elasticsearch.plugin.zentity;
+
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.BytesRestResponse;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestStatus;
+
+import static org.elasticsearch.rest.RestRequest.Method;
+import static org.elasticsearch.rest.RestRequest.Method.POST;
+
+public class SetupAction extends BaseRestHandler {
+
+    public static final int DEFAULT_NUMBER_OF_SHARDS = 1;
+    public static final int DEFAULT_NUMBER_OF_REPLICAS = 1;
+    public static final String INDEX_MAPPING = "{\n" +
+            "  \"doc\": {\n" +
+            "    \"dynamic\": \"strict\",\n" +
+            "    \"properties\": {\n" +
+            "      \"attributes\": {\n" +
+            "        \"type\": \"object\",\n" +
+            "        \"enabled\": false\n" +
+            "      },\n" +
+            "      \"resolvers\": {\n" +
+            "        \"type\": \"object\",\n" +
+            "        \"enabled\": false\n" +
+            "      },\n" +
+            "      \"matchers\": {\n" +
+            "        \"type\": \"object\",\n" +
+            "        \"enabled\": false\n" +
+            "      },\n" +
+            "      \"indices\": {\n" +
+            "        \"type\": \"object\",\n" +
+            "        \"enabled\": false\n" +
+            "      }\n" +
+            "    }\n" +
+            "  }\n" +
+            "}";
+
+    @Inject
+    public SetupAction(Settings settings, RestController controller) {
+        super(settings);
+        controller.registerHandler(POST, "_zentity/_setup", this);
+    }
+
+    /**
+     * Create the .zentity-models index.
+     *
+     * @param client           The client that will communicate with Elasticsearch.
+     * @param numberOfShards   The value of index.number_of_shards.
+     * @param numberOfReplicas The value of index.number_of_replicas.
+     * @return
+     */
+    public static CreateIndexResponse createIndex(NodeClient client, int numberOfShards, int numberOfReplicas) {
+        return client.admin().indices().prepareCreate(ModelsAction.INDEX_NAME)
+                .setSettings(Settings.builder()
+                        .put("index.number_of_shards", numberOfShards)
+                        .put("index.number_of_replicas", numberOfReplicas)
+                )
+                .addMapping("doc", INDEX_MAPPING, XContentType.JSON)
+                .get();
+    }
+
+    /**
+     * Create the .zentity-models index using the default index settings.
+     *
+     * @param client The client that will communicate with Elasticsearch.
+     * @return
+     */
+    public static CreateIndexResponse createIndex(NodeClient client) {
+        return createIndex(client, DEFAULT_NUMBER_OF_SHARDS, DEFAULT_NUMBER_OF_REPLICAS);
+    }
+
+    @Override
+    public String getName() {
+        return "zentity_setup_action";
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) {
+
+        // Parse request
+        Boolean pretty = restRequest.paramAsBoolean("pretty", false);
+        int numberOfShards = restRequest.paramAsInt("number_of_shards", 1);
+        int numberOfReplicas = restRequest.paramAsInt("number_of_replicas", 1);
+        Method method = restRequest.method();
+
+        return channel -> {
+            try {
+                if (method == POST) {
+
+                    CreateIndexResponse response = createIndex(client, numberOfShards, numberOfReplicas);
+                    XContentBuilder content = XContentFactory.jsonBuilder();
+                    if (pretty)
+                        content.prettyPrint();
+                    content = response.toXContent(content, ToXContent.EMPTY_PARAMS);
+                    channel.sendResponse(new BytesRestResponse(RestStatus.OK, content));
+
+                } else {
+                    throw new NotImplementedException("Method and endpoint not implemented.");
+                }
+            } catch (NotImplementedException e) {
+                channel.sendResponse(new BytesRestResponse(channel, RestStatus.NOT_IMPLEMENTED, e));
+            }
+        };
+    }
+}

--- a/src/main/java/org/elasticsearch/plugin/zentity/SetupAction.java
+++ b/src/main/java/org/elasticsearch/plugin/zentity/SetupAction.java
@@ -4,7 +4,6 @@ import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
@@ -97,11 +96,11 @@ public class SetupAction extends BaseRestHandler {
             try {
                 if (method == POST) {
 
-                    CreateIndexResponse response = createIndex(client, numberOfShards, numberOfReplicas);
+                    createIndex(client, numberOfShards, numberOfReplicas);
                     XContentBuilder content = XContentFactory.jsonBuilder();
                     if (pretty)
                         content.prettyPrint();
-                    content = response.toXContent(content, ToXContent.EMPTY_PARAMS);
+                    content.startObject().field("acknowledged", true).endObject();
                     channel.sendResponse(new BytesRestResponse(RestStatus.OK, content));
 
                 } else {

--- a/src/main/java/org/elasticsearch/plugin/zentity/ZentityPlugin.java
+++ b/src/main/java/org/elasticsearch/plugin/zentity/ZentityPlugin.java
@@ -1,5 +1,6 @@
 package org.elasticsearch.plugin.zentity;
 
+import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.settings.ClusterSettings;
@@ -26,6 +27,12 @@ class NotFoundException extends Exception {
 
 class NotImplementedException extends Exception {
     NotImplementedException(String message) {
+        super(message);
+    }
+}
+
+class ForbiddenException extends ElasticsearchSecurityException {
+    public ForbiddenException(String message) {
         super(message);
     }
 }
@@ -66,6 +73,7 @@ public class ZentityPlugin extends Plugin implements ActionPlugin {
             new HomeAction(settings, restController);
             new ModelsAction(settings, restController);
             new ResolutionAction(settings, restController);
+            new SetupAction(settings, restController);
         }};
         return handlers;
     }

--- a/src/test/java/io/zentity/resolution/JobIT.java
+++ b/src/test/java/io/zentity/resolution/JobIT.java
@@ -19,9 +19,36 @@ public class JobIT extends AbstractITCase {
 
     private final Map<String, String> params = Collections.emptyMap();
 
-    private final StringEntity TEST_PAYLOAD_JOB = new StringEntity("{\n" +
+    private final StringEntity TEST_PAYLOAD_JOB_ATTRIBUTES = new StringEntity("{\n" +
             "  \"attributes\": {\n" +
             "    \"attribute_a\": [ \"a_00\" ]\n" +
+            "  },\n" +
+            "  \"scope\": {\n" +
+            "    \"include\": {\n" +
+            "      \"indices\": [ \".zentity_test_index_a\", \".zentity_test_index_b\", \".zentity_test_index_c\" ],\n" +
+            "      \"resolvers\": [ \"resolver_a\", \"resolver_b\" ]\n" +
+            "    }\n" +
+            "  }\n" +
+            "}", ContentType.APPLICATION_JSON);
+
+    private final StringEntity TEST_PAYLOAD_JOB_IDS = new StringEntity("{\n" +
+            "  \"ids\": {\n" +
+            "    \".zentity_test_index_a\": [ \"a0\" ]\n" +
+            "  },\n" +
+            "  \"scope\": {\n" +
+            "    \"include\": {\n" +
+            "      \"indices\": [ \".zentity_test_index_a\", \".zentity_test_index_b\", \".zentity_test_index_c\" ],\n" +
+            "      \"resolvers\": [ \"resolver_a\", \"resolver_b\" ]\n" +
+            "    }\n" +
+            "  }\n" +
+            "}", ContentType.APPLICATION_JSON);
+
+    private final StringEntity TEST_PAYLOAD_JOB_ATTRIBUTES_IDS = new StringEntity("{\n" +
+            "  \"attributes\": {\n" +
+            "    \"attribute_a\": [ \"a_00\" ]\n" +
+            "  },\n" +
+            "  \"ids\": {\n" +
+            "    \".zentity_test_index_a\": [ \"a6\" ]\n" +
             "  },\n" +
             "  \"scope\": {\n" +
             "    \"include\": {\n" +
@@ -265,11 +292,11 @@ public class JobIT extends AbstractITCase {
         return docsActual;
     }
 
-    public void testJob() throws Exception {
+    public void testJobAttributes() throws Exception {
         try {
             prepareTestResources();
             String endpoint = "_zentity/resolution/zentity_test_entity_a";
-            Response response = client.performRequest("POST", endpoint, params, TEST_PAYLOAD_JOB);
+            Response response = client.performRequest("POST", endpoint, params, TEST_PAYLOAD_JOB_ATTRIBUTES);
             JsonNode json = Json.MAPPER.readTree(response.getEntity().getContent());
             assertEquals(json.get("hits").get("total").asInt(), 6);
 
@@ -278,6 +305,74 @@ public class JobIT extends AbstractITCase {
             docsExpected.add("b0,0");
             docsExpected.add("c0,1");
             docsExpected.add("a1,2");
+            docsExpected.add("b1,3");
+            docsExpected.add("c1,4");
+
+            assertEquals(docsExpected, getActual(json));
+        } finally {
+            destroyTestResources();
+        }
+    }
+
+    public void testJobIds() throws Exception {
+        try {
+            prepareTestResources();
+            String endpoint = "_zentity/resolution/zentity_test_entity_a";
+            Response response = client.performRequest("POST", endpoint, params, TEST_PAYLOAD_JOB_IDS);
+            JsonNode json = Json.MAPPER.readTree(response.getEntity().getContent());
+            assertEquals(json.get("hits").get("total").asInt(), 6);
+
+            Set<String> docsExpected = new TreeSet<>();
+            docsExpected.add("a0,0");
+            docsExpected.add("b0,1");
+            docsExpected.add("c0,2");
+            docsExpected.add("a1,3");
+            docsExpected.add("b1,4");
+            docsExpected.add("c1,5");
+
+            assertEquals(docsExpected, getActual(json));
+        } finally {
+            destroyTestResources();
+        }
+    }
+
+    public void testJobAttributesIds() throws Exception {
+        try {
+            prepareTestResources();
+            String endpoint = "_zentity/resolution/zentity_test_entity_a";
+            Response response = client.performRequest("POST", endpoint, params, TEST_PAYLOAD_JOB_ATTRIBUTES_IDS);
+            JsonNode json = Json.MAPPER.readTree(response.getEntity().getContent());
+            assertEquals(json.get("hits").get("total").asInt(), 30);
+
+            Set<String> docsExpected = new TreeSet<>();
+            docsExpected.add("a0,0");
+            docsExpected.add("a6,0");
+            docsExpected.add("b0,0");
+            docsExpected.add("a2,1");
+            docsExpected.add("a7,1");
+            docsExpected.add("a8,1");
+            docsExpected.add("a9,1");
+            docsExpected.add("b2,1");
+            docsExpected.add("b6,1");
+            docsExpected.add("b7,1");
+            docsExpected.add("b8,1");
+            docsExpected.add("b9,1");
+            docsExpected.add("c0,1");
+            docsExpected.add("c2,1");
+            docsExpected.add("c6,1");
+            docsExpected.add("c7,1");
+            docsExpected.add("c8,1");
+            docsExpected.add("c9,1");
+            docsExpected.add("a1,2");
+            docsExpected.add("a3,2");
+            docsExpected.add("a4,2");
+            docsExpected.add("a5,2");
+            docsExpected.add("b3,2");
+            docsExpected.add("b4,2");
+            docsExpected.add("b5,2");
+            docsExpected.add("c3,2");
+            docsExpected.add("c4,2");
+            docsExpected.add("c5,2");
             docsExpected.add("b1,3");
             docsExpected.add("c1,4");
 

--- a/src/test/java/org/elasticsearch/plugin/zentity/ResolutionActionTest.java
+++ b/src/test/java/org/elasticsearch/plugin/zentity/ResolutionActionTest.java
@@ -20,8 +20,10 @@ public class ResolutionActionTest {
     private static final String validAttributeArray = "\"attribute_array\":[\"abc\"]";
     private static final String validAttributeObject = "\"attribute_object\":{\"values\":[\"abc\"]}";
     private static final String validAttributes = "\"attributes\":{" + validAttributeArray + "," + validAttributeObject + "}";
+    private static final String validIds = "\"ids\":{\"index_name_a\":[\"a\",\"b\",\"c\"]}";
     private static final String validModel = "\"model\":" + ModelTest.VALID_OBJECT;
     private static final String validAttributesEmpty = "\"attributes\":{}";
+    private static final String validAttributesEmptyTypeNull = "\"attributes\":null";
     private static final String validAttributesTypeNull = "\"attributes\":null";
     private static final String validAttributeTypeArray = "\"attributes\":{\"attribute_name\":[\"abc\"]}";
     private static final String validAttributeTypeArrayEmpty = "\"attributes\":{\"attribute_name\":[]}";
@@ -29,6 +31,8 @@ public class ResolutionActionTest {
     private static final String validAttributeTypeBoolean = "\"attributes\":{\"attribute_type_boolean\":[true]}";
     private static final String validAttributeTypeNumber = "\"attributes\":{\"attribute_type_number\":[1.0]}";
     private static final String validAttributeTypeString = "\"attributes\":{\"attribute_type_string\":[\"abc\"]}";
+    private static final String validIdsEmpty = "\"ids\":{}";
+    private static final String validIdsEmptyTypeNull = "\"ids\":null";
 
     private static final String validScopeAttributesEmpty = "\"attributes\":{}";
     private static final String validScopeAttributesTypeNull = "\"attributes\":null";
@@ -63,6 +67,23 @@ public class ResolutionActionTest {
     private static final String invalidAttributesTypeString = "\"attributes\":\"abc\"";
     private static final String invalidAttributeNotFoundArray = "\"attributes\":{\"attribute_name_x\":[\"abc\"]}";
     private static final String invalidAttributeNotFoundObject = "\"attributes\":{\"attribute_name_x\":{\"values\":[\"abc\"]}}";
+
+    // Invalid ids
+    private static final String invalidIdsTypeArray = "\"ids\":[]";
+    private static final String invalidIdsTypeFloat = "\"ids\":1.0";
+    private static final String invalidIdsTypeInteger = "\"ids\":1";
+    private static final String invalidIdsTypeString = "\"ids\":\"abc\"";
+    private static final String invalidIdsIndexNotFound = "\"ids\":{\"index_name_x\":[\"a\",\"b\",\"c\"]}";
+    private static final String invalidIdsIndexTypeFloat = "\"ids\":1.0";
+    private static final String invalidIdsIndexTypeInteger = "\"ids\":1";
+    private static final String invalidIdsIndexTypeObject = "\"ids\":{}";
+    private static final String invalidIdsIndexTypeString = "\"ids\":\"abc\"";
+    private static final String invalidIdsIndexIdEmpty = "\"ids\":{\"index_name_a\":[\" \",\"b\",\"c\"]}";
+    private static final String invalidIdsIndexIdTypeArray = "\"ids\":{\"index_name_a\":[[],\"b\",\"c\"]}";
+    private static final String invalidIdsIndexIdTypeFloat = "\"ids\":{\"index_name_a\":[1.0,\"b\",\"c\"]}";
+    private static final String invalidIdsIndexIdTypeInteger = "\"ids\":{\"index_name_a\":[1,\"b\",\"c\"]}";
+    private static final String invalidIdsIndexIdTypeNull = "\"ids\":{\"index_name_a\":[null,\"b\",\"c\"]}";
+    private static final String invalidIdsIndexIdTypeObject = "\"ids\":{\"index_name_a\":[{},\"b\",\"c\"]}";
 
     // Invalid model
     private static final String invalidModelEmpty = "\"model\":{}";
@@ -137,6 +158,10 @@ public class ResolutionActionTest {
         return "{" + attributes + "," + validModel + "}";
     }
 
+    private static String inputIds(String ids) {
+        return "{" + ids + "," + validModel + "}";
+    }
+
     private static String inputModel(String model) {
         return "{" + validAttributes + "," + model + "}";
     }
@@ -190,17 +215,74 @@ public class ResolutionActionTest {
         parseInput(validInput, new Model(ModelTest.VALID_OBJECT));
     }
 
+    @Test
+    public void testValidInputAttributesMissing() throws Exception {
+        parseInput("{" + validIds + "}", new Model(ModelTest.VALID_OBJECT));
+    }
+
+    @Test
+    public void testValidInputAttributesEmpty() throws Exception {
+        parseInput("{" + validAttributesEmpty + "," + validIds + "}", new Model(ModelTest.VALID_OBJECT));
+        parseInput("{" + validAttributesEmptyTypeNull + "," + validIds + "}", new Model(ModelTest.VALID_OBJECT));
+    }
+
+    @Test
+    public void testValidInputIdsMissing() throws Exception {
+        parseInput("{" + validAttributes + "}", new Model(ModelTest.VALID_OBJECT));
+    }
+
+    @Test
+    public void testValidInputIdsEmpty() throws Exception {
+        parseInput("{" + validAttributes + "," + validIdsEmpty + "}", new Model(ModelTest.VALID_OBJECT));
+        parseInput("{" + validAttributes + "," + validIdsEmptyTypeNull + "}", new Model(ModelTest.VALID_OBJECT));
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidInputAttributesEmptyIdsEmpty() throws Exception {
+        parseInput("{" + validAttributesEmpty + "," + validIdsEmpty + "}", new Model(ModelTest.VALID_OBJECT));
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidInputAttributesEmptyIdsEmptyTypeNull() throws Exception {
+        parseInput("{" + validAttributesEmpty + "," + validIdsEmptyTypeNull + "}", new Model(ModelTest.VALID_OBJECT));
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidInputAttributesEmptyTypeNullIdsEmpty() throws Exception {
+        parseInput("{" + validAttributesEmptyTypeNull + "," + validIdsEmpty + "}", new Model(ModelTest.VALID_OBJECT));
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidInputAttributesEmptyTypeNullIdsEmptyTypeNull() throws Exception {
+        parseInput("{" + validAttributesEmptyTypeNull + "," + validIdsEmptyTypeNull + "}", new Model(ModelTest.VALID_OBJECT));
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidInputAttributesEmptyIdsMissing() throws Exception {
+        parseInput("{" + validAttributesEmpty + "}", new Model(ModelTest.VALID_OBJECT));
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidInputAttributesEmptyTypeNullIdsMissing() throws Exception {
+        parseInput("{" + validAttributesEmptyTypeNull + "}", new Model(ModelTest.VALID_OBJECT));
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidInputAttributesMissingIdsEmpty() throws Exception {
+        parseInput("{" + validIdsEmpty + "}", new Model(ModelTest.VALID_OBJECT));
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidInputAttributesMissingIdsEmptyTypeNull() throws Exception {
+        parseInput("{" + validIdsEmptyTypeNull + "}", new Model(ModelTest.VALID_OBJECT));
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidInputAttributesMissingIdsMissing() throws Exception {
+        parseInput("{}", new Model(ModelTest.VALID_OBJECT));
+    }
+
     ////  "attributes"  ////////////////////////////////////////////////////////////////////////////////////////////////
-
-    @Test(expected = ValidationException.class)
-    public void testValidAttributesEmpty() throws Exception {
-        new Input(inputAttributes(validAttributesEmpty), new Model(ModelTest.VALID_OBJECT));
-    }
-
-    @Test(expected = ValidationException.class)
-    public void testValidAttributesTypeNull() throws Exception {
-        new Input(inputAttributes(validAttributesTypeNull), new Model(ModelTest.VALID_OBJECT));
-    }
 
     @Test(expected = ValidationException.class)
     public void testInvalidAttributesEmpty() throws Exception {
@@ -316,6 +398,88 @@ public class ResolutionActionTest {
         new Input(input, new Model(parseRequestBody(input).get("model")));
     }
 
+    ////  "ids"  ///////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    public void testValidIds() throws Exception {
+        new Input(inputIds(validIds), new Model(ModelTest.VALID_OBJECT));
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidIdsTypeArray() throws Exception {
+        new Input(inputIds(invalidIdsTypeArray), new Model(ModelTest.VALID_OBJECT));
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidIdsTypeFloat() throws Exception {
+        new Input(inputIds(invalidIdsTypeFloat), new Model(ModelTest.VALID_OBJECT));
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidIdsTypeInteger() throws Exception {
+        new Input(inputIds(invalidIdsTypeInteger), new Model(ModelTest.VALID_OBJECT));
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidIdsTypeString() throws Exception {
+        new Input(inputIds(invalidIdsTypeString), new Model(ModelTest.VALID_OBJECT));
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidIdsIndexNotFound() throws Exception {
+        new Input(inputIds(invalidIdsIndexNotFound), new Model(ModelTest.VALID_OBJECT));
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidIdsIndexTypeFloat() throws Exception {
+        new Input(inputIds(invalidIdsIndexTypeFloat), new Model(ModelTest.VALID_OBJECT));
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidIdsIndexTypeInteger() throws Exception {
+        new Input(inputIds(invalidIdsIndexTypeInteger), new Model(ModelTest.VALID_OBJECT));
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidIdsIndexTypeObject() throws Exception {
+        new Input(inputIds(invalidIdsIndexTypeObject), new Model(ModelTest.VALID_OBJECT));
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidIdsIndexTypeString() throws Exception {
+        new Input(inputIds(invalidIdsIndexTypeString), new Model(ModelTest.VALID_OBJECT));
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidIdsIndexIdEmpty() throws Exception {
+        new Input(inputIds(invalidIdsIndexIdEmpty), new Model(ModelTest.VALID_OBJECT));
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidIdsIndexIdTypeArray() throws Exception {
+        new Input(inputIds(invalidIdsIndexIdTypeArray), new Model(ModelTest.VALID_OBJECT));
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidIdsIndexIdTypeFloat() throws Exception {
+        new Input(inputIds(invalidIdsIndexIdTypeFloat), new Model(ModelTest.VALID_OBJECT));
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidIdsIndexIdTypeInteger() throws Exception {
+        new Input(inputIds(invalidIdsIndexIdTypeInteger), new Model(ModelTest.VALID_OBJECT));
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidIdsIndexIdTypeNull() throws Exception {
+        new Input(inputIds(invalidIdsIndexIdTypeNull), new Model(ModelTest.VALID_OBJECT));
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidIdsIndexIdTypeObject() throws Exception {
+        new Input(inputIds(invalidIdsIndexIdTypeObject), new Model(ModelTest.VALID_OBJECT));
+    }
+
     ////  "model"  /////////////////////////////////////////////////////////////////////////////////////////////////////
 
     @Test(expected = ValidationException.class)
@@ -405,7 +569,7 @@ public class ResolutionActionTest {
     @Test(expected = ValidationException.class)
     public void testInvalidScopeExcludeTypeBoolean() throws Exception {
         new Input(inputScope(invalidScopeExcludeTypeBoolean), new Model(ModelTest.VALID_OBJECT));
-}
+    }
 
     @Test(expected = ValidationException.class)
     public void testInvalidScopeExcludeTypeFloat() throws Exception {


### PR DESCRIPTION
- Added the POST _zentity/_setup endpoint to create the .zentity-models index. This allows an administrator to set up the index in advance without having to give users permission to create or manage the index when using X-Pack Security. And it allows the number of shards and replicas to be defined as URI parameters.
- Added the "ids" field in the request payload of the Resolution API. This allows a job to be started by selecting document(s) by _id(s) known to be associated with an entity. Either or both of the "ids" and "attributes" fields must be present and valid to start a job.
- Fixed a NullPointerException whenever an "entity_type" does not exist when submitting a resolution job.