### PR TITLE
1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Once you have installed Elasticsearch, you can install zentity from a remote URL
 
 Example:
 
-`elasticsearch-plugin install https://zentity.io/releases/zentity-1.4.0-beta1-elasticsearch-7.2.0.zip`
+`elasticsearch-plugin install https://zentity.io/releases/zentity-1.4.0-elasticsearch-7.2.0.zip`
 
 Read the [installation](https://zentity.io/docs/installation) docs for more details.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Once you have installed Elasticsearch, you can install zentity from a remote URL
 
 Example:
 
-`elasticsearch-plugin install https://zentity.io/releases/zentity-1.3.1-elasticsearch-7.2.0.zip`
+`elasticsearch-plugin install https://zentity.io/releases/zentity-1.4.0-beta1-elasticsearch-7.2.0.zip`
 
 Read the [installation](https://zentity.io/docs/installation) docs for more details.
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <zentity.author>Dave Moore</zentity.author>
         <zentity.classname>org.elasticsearch.plugin.zentity.ZentityPlugin</zentity.classname>
         <zentity.website>https://zentity.io</zentity.website>
-        <zentity.version>1.4.0-beta1</zentity.version>
+        <zentity.version>1.4.0</zentity.version>
         <!-- dependency versions -->
         <elasticsearch.version>7.2.0</elasticsearch.version>
         <jackson.core.version>2.9.9</jackson.core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <zentity.author>Dave Moore</zentity.author>
         <zentity.classname>org.elasticsearch.plugin.zentity.ZentityPlugin</zentity.classname>
         <zentity.website>https://zentity.io</zentity.website>
-        <zentity.version>1.3.1</zentity.version>
+        <zentity.version>1.4.0-beta1</zentity.version>
         <!-- dependency versions -->
         <elasticsearch.version>7.2.0</elasticsearch.version>
         <jackson.core.version>2.9.9</jackson.core.version>

--- a/src/main/java/io/zentity/common/Patterns.java
+++ b/src/main/java/io/zentity/common/Patterns.java
@@ -6,6 +6,7 @@ public class Patterns {
 
     public static final Pattern COLON = Pattern.compile(":");
     public static final Pattern EMPTY_STRING = Pattern.compile("^\\s*$");
+    public static final Pattern NUMBER_STRING = Pattern.compile("^-?\\d*\\.{0,1}\\d+$");
     public static final Pattern PERIOD = Pattern.compile("\\.");
     public static final Pattern VARIABLE = Pattern.compile("\\{\\{\\s*([^\\s{}]+)\\s*}}");
     public static final Pattern VARIABLE_PARAMS = Pattern.compile("^params\\.(.+)");

--- a/src/main/java/io/zentity/resolution/Job.java
+++ b/src/main/java/io/zentity/resolution/Job.java
@@ -584,6 +584,7 @@ public class Job {
         // Prepare to collect attributes from the results of these queries as the inputs to subsequent queries.
         Map<String, Attribute> nextInputAttributes = new TreeMap<>();
         Boolean newHits = false;
+        int _query = 0;
 
         // Construct a query for each index that maps to a resolver.
         for (String indexName : this.input.model().indices().keySet()) {
@@ -976,7 +977,7 @@ public class Job {
                 }
                 String filtersLogged = String.join(",", filtersLoggedList);
                 String searchLogged = "{\"request\":" + query + ",\"response\":" + responseDataCopyObj + "}";
-                String logged = "{\"_hop\":" + this.hop + ",\"_index\":\"" + indexName + "\",\"filters\":{" + filtersLogged + "},\"search\":" + searchLogged + "}";
+                String logged = "{\"_hop\":" + this.hop + ",\"_query\":" + _query + ",\"_index\":\"" + indexName + "\",\"filters\":{" + filtersLogged + "},\"search\":" + searchLogged + "}";
                 this.queries.add(logged);
             }
 
@@ -1048,6 +1049,7 @@ public class Job {
                     docObjNode.remove("_score");
                     docObjNode.remove("fields");
                     docObjNode.put("_hop", this.hop);
+                    docObjNode.put("_query", _query);
                     if (this.includeAttributes) {
                         ObjectNode docAttributesObjNode = docObjNode.putObject("_attributes");
                         for (String attributeName : docAttributes.keySet()) {
@@ -1127,6 +1129,7 @@ public class Job {
                     this.hits.add(doc.toString());
                 }
             }
+            _query++;
         }
 
         // Stop traversing if we've reached max depth.

--- a/src/main/java/io/zentity/resolution/input/Term.java
+++ b/src/main/java/io/zentity/resolution/input/Term.java
@@ -1,0 +1,166 @@
+package io.zentity.resolution.input;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.zentity.common.Json;
+import io.zentity.common.Patterns;
+import io.zentity.model.ValidationException;
+import io.zentity.resolution.input.value.BooleanValue;
+import io.zentity.resolution.input.value.DateValue;
+import io.zentity.resolution.input.value.NumberValue;
+import io.zentity.resolution.input.value.StringValue;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+
+public class Term implements Comparable<Term> {
+
+    private final String term;
+    private Boolean isBoolean;
+    private Boolean isDate;
+    private Boolean isNumber;
+    private BooleanValue booleanValue;
+    private DateValue dateValue;
+    private NumberValue numberValue;
+    private StringValue stringValue;
+
+    public Term(String term) throws ValidationException {
+        validateTerm(term);
+        this.term = term;
+    }
+
+    private void validateTerm(String term) throws ValidationException {
+        if (Patterns.EMPTY_STRING.matcher(term).matches())
+            throw new ValidationException("A term must be a non-empty string.");
+    }
+
+    public String term() { return this.term; }
+
+    public static boolean isBoolean(String term) {
+        String termLowerCase = term.toLowerCase();
+        return termLowerCase.equals("true") || termLowerCase.equals("false");
+    }
+
+    public static boolean isDate(String term, String format) {
+        try {
+            SimpleDateFormat formatter = new SimpleDateFormat(format);
+            formatter.setLenient(false);
+            formatter.parse(term);
+        } catch (ParseException e) {
+            return false;
+        }
+        return true;
+    }
+
+    public static boolean isNumber(String term) {
+        return Patterns.NUMBER_STRING.matcher(term).matches();
+    }
+
+    /**
+     * Check if the term string is a boolean value.
+     * Lazily store the decision and then return the decision.
+     *
+     * @return
+     */
+    public boolean isBoolean() {
+        if (this.isBoolean == null)
+            this.isBoolean = isBoolean(this.term);
+        return this.isBoolean;
+    }
+
+    /**
+     * Check if the term string is a date value.
+     * Lazily store the decision and then return the decision.
+     *
+     * @return
+     */
+    public boolean isDate(String format) {
+        if (this.isDate == null)
+            this.isDate = isDate(this.term, format);
+        return this.isDate;
+    }
+
+    /**
+     * Convert the term to a BooleanValue.
+     * Lazily store the value and then return it.
+     *
+     * @return
+     */
+    public BooleanValue booleanValue() throws IOException, ValidationException {
+        if (this.booleanValue == null) {
+            JsonNode value = Json.MAPPER.readTree("{\"value\":" + this.term + "}").get("value");
+            this.booleanValue = new BooleanValue(value);
+        }
+        return this.booleanValue;
+    }
+
+    /**
+     * Check if the term string is a number value.
+     * Lazily store the decision and then return the decision.
+     *
+     * @return
+     */
+    public boolean isNumber() {
+        if (this.isNumber == null)
+            this.isNumber = isNumber(this.term);
+        return this.isNumber;
+    }
+
+    /**
+     * Convert the term to a DateValue.
+     * Lazily store the value and then return it.
+     *
+     * @return
+     */
+    public DateValue dateValue() throws IOException, ValidationException {
+        if (this.dateValue == null) {
+            JsonNode value = Json.MAPPER.readTree("{\"value\":" + Json.quoteString(this.term) + "}").get("value");
+            this.dateValue = new DateValue(value);
+        }
+        return this.dateValue;
+    }
+
+    /**
+     * Convert the term to a NumberValue.
+     * Lazily store the value and then return it.
+     *
+     * @return
+     */
+    public NumberValue numberValue() throws IOException, ValidationException {
+        if (this.numberValue == null) {
+            JsonNode value = Json.MAPPER.readTree("{\"value\":" + this.term + "}").get("value");
+            this.numberValue = new NumberValue(value);
+        }
+        return this.numberValue;
+    }
+
+    /**
+     * Convert the term to a StringValue.
+     * Lazily store the value and then return it.
+     *
+     * @return
+     */
+    public StringValue stringValue() throws IOException, ValidationException {
+        if (this.stringValue == null) {
+            JsonNode value = Json.MAPPER.readTree("{\"value\":" + Json.quoteString(this.term) + "}").get("value");
+            this.stringValue = new StringValue(value);
+        }
+        return this.stringValue;
+    }
+
+    @Override
+    public int compareTo(Term o) {
+        return this.term.compareTo(o.term);
+    }
+
+    @Override
+    public String toString() {
+        return this.term;
+    }
+
+    @Override
+    public boolean equals(Object o) { return this.hashCode() == o.hashCode(); }
+
+    @Override
+    public int hashCode() { return this.term.hashCode(); }
+}

--- a/src/main/java/io/zentity/resolution/input/value/Value.java
+++ b/src/main/java/io/zentity/resolution/input/value/Value.java
@@ -64,6 +64,7 @@ public abstract class Value implements ValueInterface {
         return this.serialized;
     }
 
+    @Override
     public int compareTo(Value o) {
         return this.serialized.compareTo(o.serialized);
     }
@@ -72,5 +73,11 @@ public abstract class Value implements ValueInterface {
     public String toString() {
         return this.serialized;
     }
+
+    @Override
+    public boolean equals(Object o) { return this.hashCode() == o.hashCode(); }
+
+    @Override
+    public int hashCode() { return this.serialized.hashCode(); }
 
 }

--- a/src/test/java/io/zentity/resolution/JobIT.java
+++ b/src/test/java/io/zentity/resolution/JobIT.java
@@ -36,6 +36,16 @@ public class JobIT extends AbstractITCase {
             "  }\n" +
             "}", ContentType.APPLICATION_JSON);
 
+    private final StringEntity TEST_PAYLOAD_JOB_TERMS = new StringEntity("{\n" +
+            "  \"terms\": [ \"a_00\" ],\n" +
+            "  \"scope\": {\n" +
+            "    \"include\": {\n" +
+            "      \"indices\": [ \".zentity_test_index_a\", \".zentity_test_index_b\", \".zentity_test_index_c\" ],\n" +
+            "      \"resolvers\": [ \"resolver_a\", \"resolver_b\" ]\n" +
+            "    }\n" +
+            "  }\n" +
+            "}", ContentType.APPLICATION_JSON);
+
     private final StringEntity TEST_PAYLOAD_JOB_EXPLANATION = new StringEntity("{\n" +
             "  \"attributes\": {\n" +
             "    \"attribute_a\": [ \"a_00\" ],\n" +
@@ -47,6 +57,23 @@ public class JobIT extends AbstractITCase {
             "      }\n" +
             "    }\n" +
             "  },\n" +
+            "  \"scope\": {\n" +
+            "    \"include\": {\n" +
+            "      \"indices\": [ \".zentity_test_index_a\" ]\n" +
+            "    }\n" +
+            "  }\n" +
+            "}", ContentType.APPLICATION_JSON);
+
+    private final StringEntity TEST_PAYLOAD_JOB_EXPLANATION_TERMS = new StringEntity("{\n" +
+            "  \"attributes\": {" +
+            "    \"attribute_type_date\": {" +
+            "      \"params\": {\n" +
+            "        \"format\" : \"yyyy-MM-dd'T'HH:mm:ss.0000\",\n" +
+            "        \"window\" : \"1d\"\n" +
+            "      }\n" +
+            "    }\n" +
+            "  },\n" +
+            "  \"terms\": [ \"a_00\", \"1999-12-31T23:59:57.0000\" ],\n" +
             "  \"scope\": {\n" +
             "    \"include\": {\n" +
             "      \"indices\": [ \".zentity_test_index_a\" ]\n" +
@@ -81,6 +108,19 @@ public class JobIT extends AbstractITCase {
             "  }\n" +
             "}", ContentType.APPLICATION_JSON);
 
+    private final StringEntity TEST_PAYLOAD_JOB_TERMS_IDS = new StringEntity("{\n" +
+            "  \"ids\": {\n" +
+            "    \".zentity_test_index_a\": [ \"a6\" ]\n" +
+            "  },\n" +
+            "  \"terms\": [ \"a_00\" ],\n" +
+            "  \"scope\": {\n" +
+            "    \"include\": {\n" +
+            "      \"indices\": [ \".zentity_test_index_a\", \".zentity_test_index_b\", \".zentity_test_index_c\" ],\n" +
+            "      \"resolvers\": [ \"resolver_a\", \"resolver_b\" ]\n" +
+            "    }\n" +
+            "  }\n" +
+            "}", ContentType.APPLICATION_JSON);
+
     private final StringEntity TEST_PAYLOAD_JOB_MAX_HOPS_AND_DOCS = new StringEntity("{\n" +
             "  \"attributes\": {\n" +
             "    \"attribute_d\": { \"values\": [ \"d_00\" ] }\n" +
@@ -94,6 +134,15 @@ public class JobIT extends AbstractITCase {
 
     private final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_BOOLEAN_TRUE = new StringEntity("{\n" +
             "  \"attributes\": { \"attribute_type_boolean\": [ true ] },\n" +
+            "  \"scope\": {\n" +
+            "    \"include\": {\n" +
+            "      \"indices\": [ \".zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_boolean\" ]\n" +
+            "    }\n" +
+            "  }\n" +
+            "}", ContentType.APPLICATION_JSON);
+
+    private final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_BOOLEAN_TRUE_TERMS = new StringEntity("{\n" +
+            "  \"terms\": [ \"true\" ],\n" +
             "  \"scope\": {\n" +
             "    \"include\": {\n" +
             "      \"indices\": [ \".zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_boolean\" ]\n" +
@@ -116,8 +165,31 @@ public class JobIT extends AbstractITCase {
             "  }\n" +
             "}", ContentType.APPLICATION_JSON);
 
+    private final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_DATE_TERMS = new StringEntity("{\n" +
+            "  \"attributes\": {\n" +
+            "    \"attribute_type_date\": {\n" +
+            "      \"params\": { \"format\": \"yyyy-MM-dd HH:mm:ss\", \"window\": \"1s\" }\n" +
+            "    }\n" +
+            "  },\n" +
+            "  \"terms\": [ \"d_00\", \"2000-01-01 00:00:00\" ],\n" +
+            "  \"scope\": {\n" +
+            "    \"include\": {\n" +
+            "      \"resolvers\": [ \"resolver_type_date_a\", \"resolver_type_date_b\", \"resolver_type_date_c\" ]\n" +
+            "    }\n" +
+            "  }\n" +
+            "}", ContentType.APPLICATION_JSON);
+
     private final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_BOOLEAN_FALSE = new StringEntity("{\n" +
             "  \"attributes\": { \"attribute_type_boolean\": [ false ] },\n" +
+            "  \"scope\": {\n" +
+            "    \"include\": {\n" +
+            "      \"indices\": [ \".zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_boolean\" ]\n" +
+            "    }\n" +
+            "  }\n" +
+            "}", ContentType.APPLICATION_JSON);
+
+    private final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_BOOLEAN_FALSE_TERMS = new StringEntity("{\n" +
+            "  \"terms\": [ \"false\" ],\n" +
             "  \"scope\": {\n" +
             "    \"include\": {\n" +
             "      \"indices\": [ \".zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_boolean\" ]\n" +
@@ -134,8 +206,26 @@ public class JobIT extends AbstractITCase {
             "  }\n" +
             "}", ContentType.APPLICATION_JSON);
 
+    private final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_DOUBLE_POSITIVE_TERMS = new StringEntity("{\n" +
+            "  \"terms\": [ \"3.141592653589793\" ],\n" +
+            "  \"scope\": {\n" +
+            "    \"include\": {\n" +
+            "      \"indices\": [ \".zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_double\" ]\n" +
+            "    }\n" +
+            "  }\n" +
+            "}", ContentType.APPLICATION_JSON);
+
     private final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_DOUBLE_NEGATIVE = new StringEntity("{\n" +
             "  \"attributes\": { \"attribute_type_double\": [ -3.141592653589793 ] },\n" +
+            "  \"scope\": {\n" +
+            "    \"include\": {\n" +
+            "      \"indices\": [ \".zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_double\" ]\n" +
+            "    }\n" +
+            "  }\n" +
+            "}", ContentType.APPLICATION_JSON);
+
+    private final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_DOUBLE_NEGATIVE_TERMS = new StringEntity("{\n" +
+            "  \"terms\": [ \"-3.141592653589793\" ],\n" +
             "  \"scope\": {\n" +
             "    \"include\": {\n" +
             "      \"indices\": [ \".zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_double\" ]\n" +
@@ -152,8 +242,26 @@ public class JobIT extends AbstractITCase {
             "  }\n" +
             "}", ContentType.APPLICATION_JSON);
 
+    private final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_FLOAT_POSITIVE_TERMS = new StringEntity("{\n" +
+            "  \"terms\": [ \"1.0\" ],\n" +
+            "  \"scope\": {\n" +
+            "    \"include\": {\n" +
+            "      \"indices\": [ \".zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_float\" ]\n" +
+            "    }\n" +
+            "  }\n" +
+            "}", ContentType.APPLICATION_JSON);
+
     private final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_FLOAT_NEGATIVE = new StringEntity("{\n" +
             "  \"attributes\": { \"attribute_type_float\": [ -1.0 ] },\n" +
+            "  \"scope\": {\n" +
+            "    \"include\": {\n" +
+            "      \"indices\": [ \".zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_float\" ]\n" +
+            "    }\n" +
+            "  }\n" +
+            "}", ContentType.APPLICATION_JSON);
+
+    private final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_FLOAT_NEGATIVE_TERMS = new StringEntity("{\n" +
+            "  \"terms\": [ \"-1.0\" ],\n" +
             "  \"scope\": {\n" +
             "    \"include\": {\n" +
             "      \"indices\": [ \".zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_float\" ]\n" +
@@ -170,8 +278,26 @@ public class JobIT extends AbstractITCase {
             "  }\n" +
             "}", ContentType.APPLICATION_JSON);
 
+    private final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_INTEGER_POSITIVE_TERMS = new StringEntity("{\n" +
+            "  \"terms\": [ \"1\" ],\n" +
+            "  \"scope\": {\n" +
+            "    \"include\": {\n" +
+            "      \"indices\": [ \".zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_integer\" ]\n" +
+            "    }\n" +
+            "  }\n" +
+            "}", ContentType.APPLICATION_JSON);
+
     private final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_INTEGER_NEGATIVE = new StringEntity("{\n" +
             "  \"attributes\": { \"attribute_type_integer\": [ -1 ] },\n" +
+            "  \"scope\": {\n" +
+            "    \"include\": {\n" +
+            "      \"indices\": [ \".zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_integer\" ]\n" +
+            "    }\n" +
+            "  }\n" +
+            "}", ContentType.APPLICATION_JSON);
+
+    private final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_INTEGER_NEGATIVE_TERMS = new StringEntity("{\n" +
+            "  \"terms\": [ \"-1\" ],\n" +
             "  \"scope\": {\n" +
             "    \"include\": {\n" +
             "      \"indices\": [ \".zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_integer\" ]\n" +
@@ -188,8 +314,26 @@ public class JobIT extends AbstractITCase {
             "  }\n" +
             "}", ContentType.APPLICATION_JSON);
 
+    private final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_LONG_POSITIVE_TERMS = new StringEntity("{\n" +
+            "  \"terms\": [ \"922337203685477\" ],\n" +
+            "  \"scope\": {\n" +
+            "    \"include\": {\n" +
+            "      \"indices\": [ \".zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_long\" ]\n" +
+            "    }\n" +
+            "  }\n" +
+            "}", ContentType.APPLICATION_JSON);
+
     private final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_LONG_NEGATIVE = new StringEntity("{\n" +
             "  \"attributes\": { \"attribute_type_long\": [ -922337203685477 ] },\n" +
+            "  \"scope\": {\n" +
+            "    \"include\": {\n" +
+            "      \"indices\": [ \".zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_long\" ]\n" +
+            "    }\n" +
+            "  }\n" +
+            "}", ContentType.APPLICATION_JSON);
+
+    private final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_LONG_NEGATIVE_TERMS = new StringEntity("{\n" +
+            "  \"terms\": [ \"-922337203685477\" ],\n" +
             "  \"scope\": {\n" +
             "    \"include\": {\n" +
             "      \"indices\": [ \".zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_long\" ]\n" +
@@ -206,8 +350,26 @@ public class JobIT extends AbstractITCase {
             "  }\n" +
             "}", ContentType.APPLICATION_JSON);
 
+    private final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_STRING_A_TERMS = new StringEntity("{\n" +
+            "  \"terms\": [ \"a\" ],\n" +
+            "  \"scope\": {\n" +
+            "    \"include\": {\n" +
+            "      \"indices\": [ \".zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_string\" ]\n" +
+            "    }\n" +
+            "  }\n" +
+            "}", ContentType.APPLICATION_JSON);
+
     private final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_STRING_B = new StringEntity("{\n" +
             "  \"attributes\": { \"attribute_type_string\": [ \"b\" ] },\n" +
+            "  \"scope\": {\n" +
+            "    \"include\": {\n" +
+            "      \"indices\": [ \".zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_string\" ]\n" +
+            "    }\n" +
+            "  }\n" +
+            "}", ContentType.APPLICATION_JSON);
+
+    private final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_STRING_B_TERMS = new StringEntity("{\n" +
+            "  \"terms\": [ \"b\" ],\n" +
             "  \"scope\": {\n" +
             "    \"include\": {\n" +
             "      \"indices\": [ \".zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_string\" ]\n" +
@@ -239,10 +401,34 @@ public class JobIT extends AbstractITCase {
             "  }\n" +
             "}", ContentType.APPLICATION_JSON);
 
+    private final StringEntity TEST_PAYLOAD_JOB_SCOPE_EXCLUDE_ATTRIBUTES_TERMS = new StringEntity("{\n" +
+            "  \"terms\": [ \"a_00\" ],\n" +
+            "  \"scope\": {\n" +
+            "    \"exclude\": {\n" +
+            "      \"attributes\": { \"attribute_a\":[ \"a_11\" ], \"attribute_c\": [ \"c_03\" ] }\n" +
+            "    },\n" +
+            "    \"include\": {\n" +
+            "      \"indices\": [ \".zentity_test_index_a\", \".zentity_test_index_b\", \".zentity_test_index_c\" ],\n" +
+            "      \"resolvers\": [ \"resolver_a\", \"resolver_b\", \"resolver_c\" ]\n" +
+            "    }\n" +
+            "  }\n" +
+            "}", ContentType.APPLICATION_JSON);
+
     private final StringEntity TEST_PAYLOAD_JOB_SCOPE_INCLUDE_ATTRIBUTES = new StringEntity("{\n" +
             "  \"attributes\": {\n" +
             "    \"attribute_d\": [ \"d_00\" ]\n" +
             "  },\n" +
+            "  \"scope\": {\n" +
+            "    \"include\": {\n" +
+            "      \"attributes\": { \"attribute_d\": [ \"d_00\" ], \"attribute_type_double\": [ 3.141592653589793 ] },\n" +
+            "      \"indices\": [ \".zentity_test_index_a\", \".zentity_test_index_b\", \".zentity_test_index_c\", \".zentity_test_index_d\" ],\n" +
+            "      \"resolvers\": [ \"resolver_a\", \"resolver_b\", \"resolver_c\" ]\n" +
+            "    }\n" +
+            "  }\n" +
+            "}", ContentType.APPLICATION_JSON);
+
+    private final StringEntity TEST_PAYLOAD_JOB_SCOPE_INCLUDE_ATTRIBUTES_TERMS = new StringEntity("{\n" +
+            "  \"terms\": [ \"d_00\" ],\n" +
             "  \"scope\": {\n" +
             "    \"include\": {\n" +
             "      \"attributes\": { \"attribute_d\": [ \"d_00\" ], \"attribute_type_double\": [ 3.141592653589793 ] },\n" +
@@ -268,7 +454,21 @@ public class JobIT extends AbstractITCase {
             "  }\n" +
             "}", ContentType.APPLICATION_JSON);
 
-    private final StringEntity TEST_PAYLOAD_JOB_RESOLVER_WEIGHT= new StringEntity("{\n" +
+    private final StringEntity TEST_PAYLOAD_JOB_SCOPE_EXCLUDE_AND_INCLUDE_ATTRIBUTES_TERMS = new StringEntity("{\n" +
+            "  \"terms\": [ \"d_00\" ],\n" +
+            "  \"scope\": {\n" +
+            "    \"exclude\": {\n" +
+            "      \"attributes\": { \"attribute_c\": [ \"c_00\", \"c_01\" ] }\n" +
+            "    },\n" +
+            "    \"include\": {\n" +
+            "      \"attributes\": { \"attribute_d\": [ \"d_00\" ], \"attribute_type_double\": [ 3.141592653589793 ] },\n" +
+            "      \"indices\": [ \".zentity_test_index_a\", \".zentity_test_index_b\", \".zentity_test_index_c\", \".zentity_test_index_d\" ],\n" +
+            "      \"resolvers\": [ \"resolver_a\", \"resolver_b\", \"resolver_c\" ]\n" +
+            "    }\n" +
+            "  }\n" +
+            "}", ContentType.APPLICATION_JSON);
+
+    private final StringEntity TEST_PAYLOAD_JOB_RESOLVER_WEIGHT = new StringEntity("{\n" +
             "  \"attributes\": {\n" +
             "    \"attribute_a\": [ \"a_10\" ],\n" +
             "    \"attribute_b\": [ \"b_10\" ]\n" +
@@ -395,6 +595,30 @@ public class JobIT extends AbstractITCase {
         }
     }
 
+    public void testJobTerms() throws Exception {
+        prepareTestResources();
+        try {
+            String endpoint = "_zentity/resolution/zentity_test_entity_a";
+            Request postResolution = new Request("POST", endpoint);
+            postResolution.setEntity(TEST_PAYLOAD_JOB_TERMS);
+            Response response = client.performRequest(postResolution);
+            JsonNode json = Json.MAPPER.readTree(response.getEntity().getContent());
+            assertEquals(json.get("hits").get("total").asInt(), 6);
+
+            Set<String> docsExpected = new TreeSet<>();
+            docsExpected.add("a0,0");
+            docsExpected.add("b0,0");
+            docsExpected.add("c0,1");
+            docsExpected.add("a1,2");
+            docsExpected.add("b1,3");
+            docsExpected.add("c1,4");
+
+            assertEquals(docsExpected, getActual(json));
+        } finally {
+            destroyTestResources();
+        }
+    }
+
     public void testJobExplanation() throws Exception {
         prepareTestResources();
         try {
@@ -406,6 +630,48 @@ public class JobIT extends AbstractITCase {
             postResolution.addParameter("max_hops", "1");
             postResolution.addParameter("max_docs_per_query", "2");
             postResolution.setEntity(TEST_PAYLOAD_JOB_EXPLANATION);
+            Response response = client.performRequest(postResolution);
+            JsonNode json = Json.MAPPER.readTree(response.getEntity().getContent());
+            assertEquals(json.get("hits").get("total").asInt(), 3);
+
+            Set<String> docsExpected = new TreeSet<>();
+            docsExpected.add("a0,0");
+            docsExpected.add("a1,1");
+            docsExpected.add("a2,1");
+            assertEquals(docsExpected, getActual(json));
+
+            for (JsonNode doc : json.get("hits").get("hits")) {
+                String expected = "";
+                switch (doc.get("_id").asText()) {
+                    case "a0":
+                        expected = "{\"resolvers\":{\"resolver_a\":{\"attributes\":[\"attribute_a\"]},\"resolver_type_date_a\":{\"attributes\":[\"attribute_a\",\"attribute_type_date\"]}},\"matches\":[{\"attribute\":\"attribute_a\",\"target_field\":\"field_a.clean\",\"target_value\":\"a_00\",\"input_value\":\"a_00\",\"input_matcher\":\"matcher_a\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_a\",\"target_field\":\"field_a.keyword\",\"target_value\":\"a_00\",\"input_value\":\"a_00\",\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type_date\",\"target_field\":\"type_date\",\"target_value\":\"1999-12-31T23:59:57.0000\",\"input_value\":\"1999-12-31T23:59:57.0000\",\"input_matcher\":\"matcher_c\",\"input_matcher_params\":{\"format\":\"yyyy-MM-dd'T'HH:mm:ss.0000\",\"window\":\"1d\"}}]}";
+                        break;
+                    case "a1":
+                        expected = "{\"resolvers\":{\"resolver_c\":{\"attributes\":[\"attribute_d\"]},\"resolver_type_date_c\":{\"attributes\":[\"attribute_d\",\"attribute_type_date\"]}},\"matches\":[{\"attribute\":\"attribute_d\",\"target_field\":\"field_d.clean\",\"target_value\":\"d_00\",\"input_value\":\"d_00\",\"input_matcher\":\"matcher_a\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_d\",\"target_field\":\"field_d.keyword\",\"target_value\":\"d_00\",\"input_value\":\"d_00\",\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type_date\",\"target_field\":\"type_date\",\"target_value\":\"1999-12-31T23:59:59.0000\",\"input_value\":\"1999-12-31T23:59:57.0000\",\"input_matcher\":\"matcher_c\",\"input_matcher_params\":{\"format\":\"yyyy-MM-dd'T'HH:mm:ss.0000\",\"window\":\"1d\"}}]}";
+                        break;
+                    case "a2":
+                        expected = "{\"resolvers\":{\"resolver_c\":{\"attributes\":[\"attribute_d\"]},\"resolver_object\":{\"attributes\":[\"attribute_object\"]},\"resolver_type_boolean\":{\"attributes\":[\"attribute_type_boolean\"]},\"resolver_type_date_c\":{\"attributes\":[\"attribute_d\",\"attribute_type_date\"]},\"resolver_type_double\":{\"attributes\":[\"attribute_type_double\"]},\"resolver_type_float\":{\"attributes\":[\"attribute_type_float\"]},\"resolver_type_integer\":{\"attributes\":[\"attribute_type_integer\"]},\"resolver_type_long\":{\"attributes\":[\"attribute_type_long\"]},\"resolver_type_string\":{\"attributes\":[\"attribute_type_string\"]}},\"matches\":[{\"attribute\":\"attribute_d\",\"target_field\":\"field_d.clean\",\"target_value\":\"d_00\",\"input_value\":\"d_00\",\"input_matcher\":\"matcher_a\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_d\",\"target_field\":\"field_d.keyword\",\"target_value\":\"d_00\",\"input_value\":\"d_00\",\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_object\",\"target_field\":\"object.a.b.c.keyword\",\"target_value\":\"a\",\"input_value\":\"a\",\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type_boolean\",\"target_field\":\"type_boolean\",\"target_value\":true,\"input_value\":true,\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type_date\",\"target_field\":\"type_date\",\"target_value\":\"2000-01-01T00:00:00.0000\",\"input_value\":\"1999-12-31T23:59:57.0000\",\"input_matcher\":\"matcher_c\",\"input_matcher_params\":{\"format\":\"yyyy-MM-dd'T'HH:mm:ss.0000\",\"window\":\"1d\"}},{\"attribute\":\"attribute_type_double\",\"target_field\":\"type_double\",\"target_value\":3.141592653589793,\"input_value\":3.141592653589793,\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type_float\",\"target_field\":\"type_float\",\"target_value\":1.0,\"input_value\":1.0,\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type_integer\",\"target_field\":\"type_integer\",\"target_value\":1,\"input_value\":1,\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type_long\",\"target_field\":\"type_long\",\"target_value\":922337203685477,\"input_value\":922337203685477,\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type_string\",\"target_field\":\"type_string\",\"target_value\":\"a\",\"input_value\":\"a\",\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}}]}";
+                        break;
+                }
+                assertEquals(expected, Json.MAPPER.writeValueAsString(doc.get("_explanation")));
+            }
+
+        } finally {
+            destroyTestResources();
+        }
+    }
+
+    public void testJobExplanationTerms() throws Exception {
+        prepareTestResources();
+        try {
+            String endpoint = "_zentity/resolution/zentity_test_entity_a";
+            Request postResolution = new Request("POST", endpoint);
+            postResolution.addParameter("_attributes", "false");
+            postResolution.addParameter("_explanation", "true");
+            postResolution.addParameter("_source", "false");
+            postResolution.addParameter("max_hops", "1");
+            postResolution.addParameter("max_docs_per_query", "2");
+            postResolution.setEntity(TEST_PAYLOAD_JOB_EXPLANATION_TERMS);
             Response response = client.performRequest(postResolution);
             JsonNode json = Json.MAPPER.readTree(response.getEntity().getContent());
             assertEquals(json.get("hits").get("total").asInt(), 3);
@@ -467,6 +733,54 @@ public class JobIT extends AbstractITCase {
             String endpoint = "_zentity/resolution/zentity_test_entity_a";
             Request postResolution = new Request("POST", endpoint);
             postResolution.setEntity(TEST_PAYLOAD_JOB_ATTRIBUTES_IDS);
+            Response response = client.performRequest(postResolution);
+            JsonNode json = Json.MAPPER.readTree(response.getEntity().getContent());
+            assertEquals(json.get("hits").get("total").asInt(), 30);
+
+            Set<String> docsExpected = new TreeSet<>();
+            docsExpected.add("a0,0");
+            docsExpected.add("a6,0");
+            docsExpected.add("b0,0");
+            docsExpected.add("a2,1");
+            docsExpected.add("a7,1");
+            docsExpected.add("a8,1");
+            docsExpected.add("a9,1");
+            docsExpected.add("b2,1");
+            docsExpected.add("b6,1");
+            docsExpected.add("b7,1");
+            docsExpected.add("b8,1");
+            docsExpected.add("b9,1");
+            docsExpected.add("c0,1");
+            docsExpected.add("c2,1");
+            docsExpected.add("c6,1");
+            docsExpected.add("c7,1");
+            docsExpected.add("c8,1");
+            docsExpected.add("c9,1");
+            docsExpected.add("a1,2");
+            docsExpected.add("a3,2");
+            docsExpected.add("a4,2");
+            docsExpected.add("a5,2");
+            docsExpected.add("b3,2");
+            docsExpected.add("b4,2");
+            docsExpected.add("b5,2");
+            docsExpected.add("c3,2");
+            docsExpected.add("c4,2");
+            docsExpected.add("c5,2");
+            docsExpected.add("b1,3");
+            docsExpected.add("c1,4");
+
+            assertEquals(docsExpected, getActual(json));
+        } finally {
+            destroyTestResources();
+        }
+    }
+
+    public void testJobTermsIds() throws Exception {
+        prepareTestResources();
+        try {
+            String endpoint = "_zentity/resolution/zentity_test_entity_a";
+            Request postResolution = new Request("POST", endpoint);
+            postResolution.setEntity(TEST_PAYLOAD_JOB_TERMS_IDS);
             Response response = client.performRequest(postResolution);
             JsonNode json = Json.MAPPER.readTree(response.getEntity().getContent());
             assertEquals(json.get("hits").get("total").asInt(), 30);
@@ -576,6 +890,14 @@ public class JobIT extends AbstractITCase {
             assertEquals(j1.get("hits").get("total").asInt(), 5);
             assertEquals(docsExpectedA, getActual(j1));
 
+            // Boolean true
+            Request q1t = new Request("POST", endpoint);
+            q1t.setEntity(TEST_PAYLOAD_JOB_DATA_TYPES_BOOLEAN_TRUE_TERMS);
+            Response r1t = client.performRequest(q1t);
+            JsonNode j1t = Json.MAPPER.readTree(r1t.getEntity().getContent());
+            assertEquals(j1t.get("hits").get("total").asInt(), 5);
+            assertEquals(docsExpectedA, getActual(j1t));
+
             // Boolean false
             Request q2 = new Request("POST", endpoint);
             q2.setEntity(TEST_PAYLOAD_JOB_DATA_TYPES_BOOLEAN_FALSE);
@@ -583,6 +905,14 @@ public class JobIT extends AbstractITCase {
             JsonNode j2 = Json.MAPPER.readTree(r2.getEntity().getContent());
             assertEquals(j2.get("hits").get("total").asInt(), 5);
             assertEquals(docsExpectedB, getActual(j2));
+
+            // Boolean false
+            Request q2t = new Request("POST", endpoint);
+            q2t.setEntity(TEST_PAYLOAD_JOB_DATA_TYPES_BOOLEAN_FALSE_TERMS);
+            Response r2t = client.performRequest(q2t);
+            JsonNode j2t = Json.MAPPER.readTree(r2t.getEntity().getContent());
+            assertEquals(j2t.get("hits").get("total").asInt(), 5);
+            assertEquals(docsExpectedB, getActual(j2t));
 
             // Double positive
             Request q3 = new Request("POST", endpoint);
@@ -592,6 +922,14 @@ public class JobIT extends AbstractITCase {
             assertEquals(j3.get("hits").get("total").asInt(), 5);
             assertEquals(docsExpectedA, getActual(j3));
 
+            // Double positive
+            Request q3t = new Request("POST", endpoint);
+            q3t.setEntity(TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_DOUBLE_POSITIVE_TERMS);
+            Response r3t = client.performRequest(q3t);
+            JsonNode j3t = Json.MAPPER.readTree(r3t.getEntity().getContent());
+            assertEquals(j3t.get("hits").get("total").asInt(), 5);
+            assertEquals(docsExpectedA, getActual(j3t));
+
             // Double negative
             Request q4 = new Request("POST", endpoint);
             q4.setEntity(TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_DOUBLE_NEGATIVE);
@@ -599,6 +937,14 @@ public class JobIT extends AbstractITCase {
             JsonNode j4 = Json.MAPPER.readTree(r4.getEntity().getContent());
             assertEquals(j4.get("hits").get("total").asInt(), 5);
             assertEquals(docsExpectedB, getActual(j4));
+
+            // Double negative
+            Request q4t = new Request("POST", endpoint);
+            q4t.setEntity(TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_DOUBLE_NEGATIVE_TERMS);
+            Response r4t = client.performRequest(q4t);
+            JsonNode j4t = Json.MAPPER.readTree(r4t.getEntity().getContent());
+            assertEquals(j4t.get("hits").get("total").asInt(), 5);
+            assertEquals(docsExpectedB, getActual(j4t));
 
             // Float positive
             Request q5 = new Request("POST", endpoint);
@@ -608,6 +954,14 @@ public class JobIT extends AbstractITCase {
             assertEquals(j5.get("hits").get("total").asInt(), 5);
             assertEquals(docsExpectedA, getActual(j5));
 
+            // Float positive
+            Request q5t = new Request("POST", endpoint);
+            q5t.setEntity(TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_FLOAT_POSITIVE_TERMS);
+            Response r5t = client.performRequest(q5t);
+            JsonNode j5t = Json.MAPPER.readTree(r5t.getEntity().getContent());
+            assertEquals(j5t.get("hits").get("total").asInt(), 5);
+            assertEquals(docsExpectedA, getActual(j5t));
+
             // Float negative
             Request q6 = new Request("POST", endpoint);
             q6.setEntity(TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_FLOAT_NEGATIVE);
@@ -615,6 +969,14 @@ public class JobIT extends AbstractITCase {
             JsonNode j6 = Json.MAPPER.readTree(r6.getEntity().getContent());
             assertEquals(j6.get("hits").get("total").asInt(), 5);
             assertEquals(docsExpectedB, getActual(j6));
+
+            // Float negative
+            Request q6t = new Request("POST", endpoint);
+            q6t.setEntity(TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_FLOAT_NEGATIVE_TERMS);
+            Response r6t = client.performRequest(q6t);
+            JsonNode j6t = Json.MAPPER.readTree(r6t.getEntity().getContent());
+            assertEquals(j6t.get("hits").get("total").asInt(), 5);
+            assertEquals(docsExpectedB, getActual(j6t));
 
             // Integer positive
             Request q7 = new Request("POST", endpoint);
@@ -624,6 +986,14 @@ public class JobIT extends AbstractITCase {
             assertEquals(j7.get("hits").get("total").asInt(), 5);
             assertEquals(docsExpectedA, getActual(j7));
 
+            // Integer positive
+            Request q7t = new Request("POST", endpoint);
+            q7t.setEntity(TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_INTEGER_POSITIVE_TERMS);
+            Response r7t = client.performRequest(q7t);
+            JsonNode j7t = Json.MAPPER.readTree(r7t.getEntity().getContent());
+            assertEquals(j7t.get("hits").get("total").asInt(), 5);
+            assertEquals(docsExpectedA, getActual(j7t));
+
             // Integer negative
             Request q8 = new Request("POST", endpoint);
             q8.setEntity(TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_INTEGER_NEGATIVE);
@@ -631,6 +1001,14 @@ public class JobIT extends AbstractITCase {
             JsonNode j8 = Json.MAPPER.readTree(r8.getEntity().getContent());
             assertEquals(j8.get("hits").get("total").asInt(), 5);
             assertEquals(docsExpectedB, getActual(j8));
+
+            // Integer negative
+            Request q8t = new Request("POST", endpoint);
+            q8t.setEntity(TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_INTEGER_NEGATIVE_TERMS);
+            Response r8t = client.performRequest(q8t);
+            JsonNode j8t = Json.MAPPER.readTree(r8t.getEntity().getContent());
+            assertEquals(j8t.get("hits").get("total").asInt(), 5);
+            assertEquals(docsExpectedB, getActual(j8t));
 
             // Long positive
             Request q9 = new Request("POST", endpoint);
@@ -640,6 +1018,14 @@ public class JobIT extends AbstractITCase {
             assertEquals(j9.get("hits").get("total").asInt(), 5);
             assertEquals(docsExpectedA, getActual(j9));
 
+            // Long positive
+            Request q9t = new Request("POST", endpoint);
+            q9t.setEntity(TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_LONG_POSITIVE_TERMS);
+            Response r9t = client.performRequest(q9t);
+            JsonNode j9t = Json.MAPPER.readTree(r9t.getEntity().getContent());
+            assertEquals(j9t.get("hits").get("total").asInt(), 5);
+            assertEquals(docsExpectedA, getActual(j9t));
+
             // Long negative
             Request q10 = new Request("POST", endpoint);
             q10.setEntity(TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_LONG_NEGATIVE);
@@ -647,6 +1033,14 @@ public class JobIT extends AbstractITCase {
             JsonNode j10 = Json.MAPPER.readTree(r10.getEntity().getContent());
             assertEquals(j10.get("hits").get("total").asInt(), 5);
             assertEquals(docsExpectedB, getActual(j10));
+
+            // Long negative
+            Request q10t = new Request("POST", endpoint);
+            q10t.setEntity(TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_LONG_NEGATIVE_TERMS);
+            Response r10t = client.performRequest(q10t);
+            JsonNode j10t = Json.MAPPER.readTree(r10t.getEntity().getContent());
+            assertEquals(j10t.get("hits").get("total").asInt(), 5);
+            assertEquals(docsExpectedB, getActual(j10t));
 
             // String A
             Request q11 = new Request("POST", endpoint);
@@ -656,6 +1050,14 @@ public class JobIT extends AbstractITCase {
             assertEquals(j11.get("hits").get("total").asInt(), 5);
             assertEquals(docsExpectedA, getActual(j11));
 
+            // String A
+            Request q11t = new Request("POST", endpoint);
+            q11t.setEntity(TEST_PAYLOAD_JOB_DATA_TYPES_STRING_A_TERMS);
+            Response r11t = client.performRequest(q11t);
+            JsonNode j11t = Json.MAPPER.readTree(r11t.getEntity().getContent());
+            assertEquals(j11t.get("hits").get("total").asInt(), 5);
+            assertEquals(docsExpectedA, getActual(j11t));
+
             // String B
             Request q12 = new Request("POST", endpoint);
             q12.setEntity(TEST_PAYLOAD_JOB_DATA_TYPES_STRING_B);
@@ -663,6 +1065,14 @@ public class JobIT extends AbstractITCase {
             JsonNode j12 = Json.MAPPER.readTree(r12.getEntity().getContent());
             assertEquals(j12.get("hits").get("total").asInt(), 5);
             assertEquals(docsExpectedB, getActual(j12));
+
+            // String B
+            Request q12t = new Request("POST", endpoint);
+            q12t.setEntity(TEST_PAYLOAD_JOB_DATA_TYPES_STRING_B_TERMS);
+            Response r12t = client.performRequest(q12t);
+            JsonNode j12t = Json.MAPPER.readTree(r12t.getEntity().getContent());
+            assertEquals(j12t.get("hits").get("total").asInt(), 5);
+            assertEquals(docsExpectedB, getActual(j12t));
 
         } finally {
             destroyTestResources();
@@ -677,6 +1087,81 @@ public class JobIT extends AbstractITCase {
             postResolution.addParameter("max_hops", "2");
             postResolution.addParameter("max_docs_per_query", "2");
             postResolution.setEntity(TEST_PAYLOAD_JOB_DATA_TYPES_DATE);
+            Response response = client.performRequest(postResolution);
+            JsonNode json = Json.MAPPER.readTree(response.getEntity().getContent());
+
+            /*
+            Elasticsearch 7.0.0+ has a different behavior when querying date ranges.
+
+            To demonstrate, compare this query (below) with the test indices, data, and entity models on Elasticsearch
+            versions 6.7.1 and 7.0.0:
+
+            GET .zentity_test_index_d/_search
+            {
+              "query": {
+                "bool": {
+                  "filter": [
+                    {
+                      "range": {
+                        "type_date": {
+                          "gte": "2000-01-01 00:00:01||-2s",
+                          "lte": "2000-01-01 00:00:01||+2s",
+                          "format": "yyyy-MM-dd HH:mm:ss"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+
+            In 7.0.0 the result has a fourth hit ("_id" = "d3") where the "type_date" field is "2000-01-01T00:00:02.500",
+            which is a half second greater than the 2s window that was specified in the search.
+
+            We'll allow this behavior in the test, since this is a behavior of Elasticsearch and not zentity.
+            */
+            Properties props = new Properties();
+            props.load(ZentityPlugin.class.getResourceAsStream("/plugin-descriptor.properties"));
+            if (props.getProperty("elasticsearch.version").compareTo("7.") >= 0) {
+                assertEquals(json.get("hits").get("total").asInt(), 15);
+            } else {
+                assertEquals(json.get("hits").get("total").asInt(), 13);
+            }
+            Set<String> docsExpected = new TreeSet<>();
+            docsExpected.add("a1,0");
+            docsExpected.add("a2,0");
+            docsExpected.add("b0,0");
+            docsExpected.add("c0,0");
+            docsExpected.add("d0,0");
+            docsExpected.add("d1,0");
+            docsExpected.add("a3,1");
+            docsExpected.add("b3,1");
+            docsExpected.add("c1,1");
+            docsExpected.add("d2,1");
+            docsExpected.add("b1,2");
+            docsExpected.add("c3,2");
+            if (props.getProperty("elasticsearch.version").compareTo("7.") >= 0) {
+                docsExpected.add("d3,1");
+                docsExpected.add("a4,2");
+                docsExpected.add("c4,2");
+            } else {
+                docsExpected.add("d3,2");
+            }
+
+            assertEquals(docsExpected, getActual(json));
+        } finally {
+            destroyTestResources();
+        }
+    }
+
+    public void testJobDataTypesDateTerm() throws Exception {
+        prepareTestResources();
+        try {
+            String endpoint = "_zentity/resolution/zentity_test_entity_a?max_hops=2&max_docs_per_query=2";
+            Request postResolution = new Request("POST", endpoint);
+            postResolution.addParameter("max_hops", "2");
+            postResolution.addParameter("max_docs_per_query", "2");
+            postResolution.setEntity(TEST_PAYLOAD_JOB_DATA_TYPES_DATE_TERMS);
             Response response = client.performRequest(postResolution);
             JsonNode json = Json.MAPPER.readTree(response.getEntity().getContent());
 
@@ -803,6 +1288,40 @@ public class JobIT extends AbstractITCase {
         }
     }
 
+    public void testJobScopeExcludeAttributesTerms() throws Exception {
+        prepareTestResources();
+        try {
+            String endpoint = "_zentity/resolution/zentity_test_entity_a";
+            Request postResolution = new Request("POST", endpoint);
+            postResolution.setEntity(TEST_PAYLOAD_JOB_SCOPE_EXCLUDE_ATTRIBUTES_TERMS);
+            Response response = client.performRequest(postResolution);
+            JsonNode json = Json.MAPPER.readTree(response.getEntity().getContent());
+            assertEquals(json.get("hits").get("total").asInt(), 16);
+
+            Set<String> docsExpected = new TreeSet<>();
+            docsExpected.add("a0,0");
+            docsExpected.add("b0,0");
+            docsExpected.add("a2,1");
+            docsExpected.add("b2,1");
+            docsExpected.add("c0,1");
+            docsExpected.add("c1,1");
+            docsExpected.add("c2,1");
+            docsExpected.add("a3,2");
+            docsExpected.add("a4,2");
+            docsExpected.add("a5,2");
+            docsExpected.add("b3,2");
+            docsExpected.add("b4,2");
+            docsExpected.add("b5,2");
+            docsExpected.add("c3,2");
+            docsExpected.add("c4,2");
+            docsExpected.add("c5,2");
+
+            assertEquals(docsExpected, getActual(json));
+        } finally {
+            destroyTestResources();
+        }
+    }
+
     public void testJobScopeIncludeAttributes() throws Exception {
         prepareTestResources();
         try {
@@ -829,12 +1348,60 @@ public class JobIT extends AbstractITCase {
         }
     }
 
+    public void testJobScopeIncludeAttributesTerms() throws Exception {
+        prepareTestResources();
+        try {
+            String endpoint = "_zentity/resolution/zentity_test_entity_a";
+            Request postResolution = new Request("POST", endpoint);
+            postResolution.setEntity(TEST_PAYLOAD_JOB_SCOPE_INCLUDE_ATTRIBUTES_TERMS);
+            Response response = client.performRequest(postResolution);
+            JsonNode json = Json.MAPPER.readTree(response.getEntity().getContent());
+            assertEquals(json.get("hits").get("total").asInt(), 8);
+
+            Set<String> docsExpected = new TreeSet<>();
+            docsExpected.add("a0,0");
+            docsExpected.add("a2,0");
+            docsExpected.add("b0,0");
+            docsExpected.add("b2,0");
+            docsExpected.add("c0,0");
+            docsExpected.add("c2,0");
+            docsExpected.add("d0,0");
+            docsExpected.add("d2,0");
+
+            assertEquals(docsExpected, getActual(json));
+        } finally {
+            destroyTestResources();
+        }
+    }
+
     public void testJobScopeExcludeAndIncludeAttributes() throws Exception {
         prepareTestResources();
         try {
             String endpoint = "_zentity/resolution/zentity_test_entity_a";
             Request postResolution = new Request("POST", endpoint);
             postResolution.setEntity(TEST_PAYLOAD_JOB_SCOPE_EXCLUDE_AND_INCLUDE_ATTRIBUTES);
+            Response response = client.performRequest(postResolution);
+            JsonNode json = Json.MAPPER.readTree(response.getEntity().getContent());
+            assertEquals(json.get("hits").get("total").asInt(), 4);
+
+            Set<String> docsExpected = new TreeSet<>();
+            docsExpected.add("a2,0");
+            docsExpected.add("b2,0");
+            docsExpected.add("c2,0");
+            docsExpected.add("d2,0");
+
+            assertEquals(docsExpected, getActual(json));
+        } finally {
+            destroyTestResources();
+        }
+    }
+
+    public void testJobScopeExcludeAndIncludeAttributesTerms() throws Exception {
+        prepareTestResources();
+        try {
+            String endpoint = "_zentity/resolution/zentity_test_entity_a";
+            Request postResolution = new Request("POST", endpoint);
+            postResolution.setEntity(TEST_PAYLOAD_JOB_SCOPE_EXCLUDE_AND_INCLUDE_ATTRIBUTES_TERMS);
             Response response = client.performRequest(postResolution);
             JsonNode json = Json.MAPPER.readTree(response.getEntity().getContent());
             assertEquals(json.get("hits").get("total").asInt(), 4);

--- a/src/test/java/io/zentity/resolution/input/TermTest.java
+++ b/src/test/java/io/zentity/resolution/input/TermTest.java
@@ -1,0 +1,194 @@
+package io.zentity.resolution.input;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.zentity.common.Json;
+import io.zentity.model.ValidationException;
+import io.zentity.resolution.input.value.Value;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TermTest {
+
+    ////  "terms".TERM  ////////////////////////////////////////////////////////////////////////////////////////////////
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidTypeEmptyString() throws Exception {
+        new Term("");
+    }
+    @Test(expected = ValidationException.class)
+    public void testInvalidTypeEmptyStringWhitespace() throws Exception {
+        new Term(" ");
+    }
+
+    ////  Value type detection  ////////////////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    public void testValidTypeBooleanFalse() throws Exception {
+        Term term = new Term("false");
+        Assert.assertTrue(term.isBoolean());
+        Assert.assertFalse(term.isNumber());
+    }
+
+    @Test
+    public void testValidTypeBooleanTrue() throws Exception {
+        Term term = new Term("true");
+        Assert.assertTrue(term.isBoolean());
+        Assert.assertFalse(term.isNumber());
+    }
+
+    @Test
+    public void testValidTypeDate() throws Exception {
+        Term term = new Term("2019-12-31 12:45:00");
+        Assert.assertFalse(term.isBoolean());
+        Assert.assertTrue(term.isDate("yyyy-MM-dd HH:mm:ss"));
+        Assert.assertFalse(term.isNumber());
+    }
+
+    @Test
+    public void testInvalidTypeDate() throws Exception {
+        Term term = new Term("2019-12-31 12:45:00");
+        Assert.assertFalse(term.isDate("yyyyMMdd"));
+    }
+
+    @Test
+    public void testValidTypeNumberIntegerLongNegative() throws Exception {
+        Term term = new Term("-922337203685477");
+        Assert.assertFalse(term.isBoolean());
+        Assert.assertTrue(term.isNumber());
+    }
+
+    @Test
+    public void testValidTypeNumberIntegerLongPositive() throws Exception {
+        Term term = new Term("922337203685477");
+        Assert.assertFalse(term.isBoolean());
+        Assert.assertTrue(term.isNumber());
+    }
+
+    @Test
+    public void testValidTypeNumberIntegerShortNegative() throws Exception {
+        Term term = new Term("-1");
+        Assert.assertFalse(term.isBoolean());
+        Assert.assertTrue(term.isNumber());
+    }
+
+    @Test
+    public void testValidTypeNumberIntegerShortPositive() throws Exception {
+        Term term = new Term("1");
+        Assert.assertFalse(term.isBoolean());
+        Assert.assertTrue(term.isNumber());
+    }
+
+    @Test
+    public void testValidTypeNumberFloatLongNegative() throws Exception {
+        Term term = new Term("-3.141592653589793");
+        Assert.assertFalse(term.isBoolean());
+        Assert.assertTrue(term.isNumber());
+    }
+
+    @Test
+    public void testValidTypeNumberFloatLongPositive() throws Exception {
+        Term term = new Term("3.141592653589793");
+        Assert.assertFalse(term.isBoolean());
+        Assert.assertTrue(term.isNumber());
+    }
+
+    @Test
+    public void testValidTypeNumberFloatShortNegative() throws Exception {
+        Term term = new Term("-1.0");
+        Assert.assertFalse(term.isBoolean());
+        Assert.assertTrue(term.isNumber());
+    }
+
+    @Test
+    public void testValidTypeNumberFloatShortPositive() throws Exception {
+        Term term = new Term("1.0");
+        Assert.assertFalse(term.isBoolean());
+        Assert.assertTrue(term.isNumber());
+    }
+
+    ////  Value conversion  ////////////////////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    public void testValueConversionBooleanFalse() throws Exception {
+        Term term = new Term("false");
+        JsonNode value = Json.MAPPER.readTree("{\"value\":false}").get("value");
+        Assert.assertEquals(term.booleanValue(), Value.create("boolean", value));
+    }
+
+    @Test
+    public void testValueConversionBooleanTrue() throws Exception {
+        Term term = new Term("true");
+        JsonNode value = Json.MAPPER.readTree("{\"value\":true}").get("value");
+        Assert.assertEquals(term.booleanValue(), Value.create("boolean", value));
+    }
+
+    @Test
+    public void testValueConversionDate() throws Exception {
+        Term term = new Term("2019-12-31 12:45:00");
+        JsonNode value = Json.MAPPER.readTree("{\"value\":\"2019-12-31 12:45:00\"}").get("value");
+        Assert.assertEquals(term.dateValue(), Value.create("date", value));
+    }
+
+    @Test
+    public void testValueConversionNumberIntegerLongNegative() throws Exception {
+        Term term = new Term("-922337203685477");
+        JsonNode value = Json.MAPPER.readTree("{\"value\":-922337203685477}").get("value");
+        Assert.assertEquals(term.numberValue(), Value.create("number", value));
+    }
+
+    @Test
+    public void testValueConversionNumberIntegerLongPositive() throws Exception {
+        Term term = new Term("922337203685477");
+        JsonNode value = Json.MAPPER.readTree("{\"value\":922337203685477}").get("value");
+        Assert.assertEquals(term.numberValue(), Value.create("number", value));
+    }
+
+    @Test
+    public void testValueConversionNumberIntegerShortNegative() throws Exception {
+        Term term = new Term("-1");
+        JsonNode value = Json.MAPPER.readTree("{\"value\":-1}").get("value");
+        Assert.assertEquals(term.numberValue(), Value.create("number", value));
+    }
+
+    @Test
+    public void testValueConversionNumberIntegerShortPositive() throws Exception {
+        Term term = new Term("1");
+        JsonNode value = Json.MAPPER.readTree("{\"value\":1}").get("value");
+        Assert.assertEquals(term.numberValue(), Value.create("number", value));
+    }
+
+    @Test
+    public void testValueConversionNumberFloatLongNegative() throws Exception {
+        Term term = new Term("-3.141592653589793");
+        JsonNode value = Json.MAPPER.readTree("{\"value\":-3.141592653589793}").get("value");
+        Assert.assertEquals(term.numberValue(), Value.create("number", value));
+    }
+
+    @Test
+    public void testValueConversionNumberFloatLongPositive() throws Exception {
+        Term term = new Term("3.141592653589793");
+        JsonNode value = Json.MAPPER.readTree("{\"value\":3.141592653589793}").get("value");
+        Assert.assertEquals(term.numberValue(), Value.create("number", value));
+    }
+
+    @Test
+    public void testValueConversionNumberFloatShortNegative() throws Exception {
+        Term term = new Term("-1.0");
+        JsonNode value = Json.MAPPER.readTree("{\"value\":-1.0}").get("value");
+        Assert.assertEquals(term.numberValue(), Value.create("number", value));
+    }
+
+    @Test
+    public void testValueConversionNumberFloatShortPositive() throws Exception {
+        Term term = new Term("1.0");
+        JsonNode value = Json.MAPPER.readTree("{\"value\":1.0}").get("value");
+        Assert.assertEquals(term.numberValue(), Value.create("number", value));
+    }
+
+    @Test
+    public void testValueConversionString() throws Exception {
+        Term term = new Term("abc");
+        JsonNode value = Json.MAPPER.readTree("{\"value\":\"abc\"}").get("value");
+        Assert.assertEquals(term.stringValue(), Value.create("string", value));
+    }
+}

--- a/src/test/java/org/elasticsearch/plugin/zentity/ResolutionActionTest.java
+++ b/src/test/java/org/elasticsearch/plugin/zentity/ResolutionActionTest.java
@@ -24,13 +24,15 @@ public class ResolutionActionTest {
     private static final String validModel = "\"model\":" + ModelTest.VALID_OBJECT;
     private static final String validAttributesEmpty = "\"attributes\":{}";
     private static final String validAttributesEmptyTypeNull = "\"attributes\":null";
-    private static final String validAttributesTypeNull = "\"attributes\":null";
     private static final String validAttributeTypeArray = "\"attributes\":{\"attribute_name\":[\"abc\"]}";
     private static final String validAttributeTypeArrayEmpty = "\"attributes\":{\"attribute_name\":[]}";
     private static final String validAttributeTypeNull = "\"attributes\":{\"attribute_name\":null}";
     private static final String validAttributeTypeBoolean = "\"attributes\":{\"attribute_type_boolean\":[true]}";
     private static final String validAttributeTypeNumber = "\"attributes\":{\"attribute_type_number\":[1.0]}";
     private static final String validAttributeTypeString = "\"attributes\":{\"attribute_type_string\":[\"abc\"]}";
+    private static final String validTermsEmpty = "\"terms\":[]";
+    private static final String validTermsEmptyTypeNull = "\"terms\":null";
+    private static final String validTermsTypeArray = "\"terms\":[\"abc\"]";
     private static final String validIdsEmpty = "\"ids\":{}";
     private static final String validIdsEmptyTypeNull = "\"ids\":null";
 
@@ -67,6 +69,12 @@ public class ResolutionActionTest {
     private static final String invalidAttributesTypeString = "\"attributes\":\"abc\"";
     private static final String invalidAttributeNotFoundArray = "\"attributes\":{\"attribute_name_x\":[\"abc\"]}";
     private static final String invalidAttributeNotFoundObject = "\"attributes\":{\"attribute_name_x\":{\"values\":[\"abc\"]}}";
+
+    // Invalid terms
+    private static final String invalidTermsTypeArray = "\"terms\":{}";
+    private static final String invalidTermsTypeFloat = "\"terms\":1.0";
+    private static final String invalidTermsTypeInteger = "\"terms\":1";
+    private static final String invalidTermsTypeString = "\"terms\":\"abc\"";
 
     // Invalid ids
     private static final String invalidIdsTypeArray = "\"ids\":[]";
@@ -228,6 +236,17 @@ public class ResolutionActionTest {
     public void testValidInputAttributesEmpty() throws Exception {
         parseInput("{" + validAttributesEmpty + "," + validIds + "}", new Model(ModelTest.VALID_OBJECT));
         parseInput("{" + validAttributesEmptyTypeNull + "," + validIds + "}", new Model(ModelTest.VALID_OBJECT));
+    }
+
+    @Test
+    public void testValidInputTermsEmpty() throws Exception {
+        parseInput("{" + validAttributes + "," + validTermsEmpty + "}", new Model(ModelTest.VALID_OBJECT));
+        parseInput("{" + validAttributes + "," + validTermsEmptyTypeNull + "}", new Model(ModelTest.VALID_OBJECT));
+    }
+
+    @Test
+    public void testValidInputTermsArray() throws Exception {
+        parseInput("{" + validTermsTypeArray+ "}", new Model(ModelTest.VALID_OBJECT));
     }
 
     @Test
@@ -400,6 +419,28 @@ public class ResolutionActionTest {
     public void testInvalidAttributeTypeStringWhenNumber() throws Exception {
         String input = inputModelAttributeTypes("\"attributes\":{\"attribute_type_string\":[1.0]}");
         new Input(input);
+    }
+
+    ////  "terms"  ////////////////////////////////////////////////////////////////////////////////////////////////
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidTermsTypeArray() throws Exception {
+        new Input(inputAttributes(invalidTermsTypeArray));
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidTermsTypeFloat() throws Exception {
+        new Input(inputAttributes(invalidTermsTypeFloat));
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidTermsTypeInteger() throws Exception {
+        new Input(inputAttributes(invalidTermsTypeInteger));
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidTermsTypeString() throws Exception {
+        new Input(inputAttributes(invalidTermsTypeString));
     }
 
     ////  "ids"  ///////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
- **Feature** - Added an optional `"terms"` field to the resolution input which allows resolutions jobs to be submitted with unknown or unstructured input values.
- **Feature** - Added a `"_query"` field to each object under `"hit"."hits"` and `"queries"` to indicate which query of which hop that the object relates to.
- **Breaking change** - Renamed `"queries"."resolvers"` to `"queries"."filters"` and changed its structure.