### PR TITLE
feat: enforce entity name requirements

### DIFF
--- a/src/main/java/org/elasticsearch/plugin/zentity/ModelsAction.java
+++ b/src/main/java/org/elasticsearch/plugin/zentity/ModelsAction.java
@@ -4,6 +4,7 @@ import io.zentity.model.Model;
 import io.zentity.model.ValidationException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionResponse;
@@ -14,14 +15,20 @@ import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexNotFoundException;
-import org.elasticsearch.rest.*;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestRequest;
 
+import java.io.UnsupportedEncodingException;
 import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.function.BiFunction;
 
 import static org.elasticsearch.rest.RestRequest.Method;
 import static org.elasticsearch.rest.RestRequest.Method.DELETE;
@@ -30,6 +37,57 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.rest.RestRequest.Method.PUT;
 
 public class ModelsAction extends BaseRestHandler {
+    public static final int MAX_ENTITY_TYPE_BYTES = 255;
+
+    /**
+     * Check if an entity type meets the name requirements, as specified by the Elasticsearch index
+     * naming requirements.
+     *
+     * @param entityType The entity type.
+     * @return an optional ValidationException if the type is not in a valid format.
+     * @see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/7.10/indices-create-index.html#indices-create-api-path-params">Elasticsearch Index Name Requirements</a>
+     * @see org.elasticsearch.cluster.metadata.MetadataCreateIndexService#validateIndexOrAliasName
+     */
+    public static Optional<Exception> validateEntityType(String entityType) {
+        BiFunction<String, String, ValidationException> errorConstructor = (name, description) -> {
+            String message = "Invalid entity type [" + name + "], " + description;
+            return new ValidationException(message);
+        };
+
+        Exception ex = null;
+        if (!Strings.validFileName(entityType)) {
+            ex = errorConstructor.apply(entityType, "must not contain the following characters " + Strings.INVALID_FILENAME_CHARS);
+        }
+        if (entityType.contains("#")) {
+            ex = errorConstructor.apply(entityType, "must not contain '#'");
+        }
+        if (entityType.contains(":")) {
+            ex = errorConstructor.apply(entityType, "must not contain ':'");
+        }
+        if (entityType.charAt(0) == '_' || entityType.charAt(0) == '-' || entityType.charAt(0) == '+') {
+            ex = errorConstructor.apply(entityType, "must not start with '_', '-', or '+'");
+        }
+        int byteCount = 0;
+        try {
+            byteCount = entityType.getBytes("UTF-8").length;
+        } catch (UnsupportedEncodingException e) {
+            // UTF-8 should always be supported, but rethrow this if it is not for some reason
+            ex = new ElasticsearchException("Unable to determine length of entity type", e);
+        }
+
+        if (byteCount > MAX_ENTITY_TYPE_BYTES) {
+            ex = errorConstructor.apply(entityType, "entity type is too long, (" + byteCount + " > " + MAX_ENTITY_TYPE_BYTES + ")");
+        }
+        if (entityType.equals(".") || entityType.equals("..")) {
+            ex = errorConstructor.apply(entityType, "must not be '.' or '..'");
+        }
+
+        if (!entityType.toLowerCase(Locale.ROOT).equals(entityType)) {
+            ex = errorConstructor.apply(entityType, "must be lowercase");
+        }
+
+        return Optional.ofNullable(ex);
+    }
 
     private static final Logger logger = LogManager.getLogger(ModelsAction.class);
     public static final String INDEX_NAME = ".zentity-models";
@@ -288,6 +346,11 @@ public class ModelsAction extends BaseRestHandler {
      * @param onComplete  The action to perform after indexing the entity model.
      */
     public static void indexEntityModel(String entityType, String requestBody, NodeClient client, ActionListener<IndexResponse> onComplete) {
+        Optional<Exception> validationExOpt = validateEntityType(entityType);
+        if (validationExOpt.isPresent()) {
+            onComplete.onFailure(validationExOpt.get());
+            return;
+        }
         ensureIndex(client, new ActionListener<>() {
 
             @Override
@@ -325,6 +388,11 @@ public class ModelsAction extends BaseRestHandler {
      * @param onComplete  The action to perform after updating the entity model.
      */
     public static void updateEntityModel(String entityType, String requestBody, NodeClient client, ActionListener<IndexResponse> onComplete) {
+        Optional<Exception> validationExOpt = validateEntityType(entityType);
+        if (validationExOpt.isPresent()) {
+            onComplete.onFailure(validationExOpt.get());
+            return;
+        }
         ensureIndex(client, new ActionListener<>() {
 
             @Override
@@ -356,9 +424,9 @@ public class ModelsAction extends BaseRestHandler {
     /**
      * Delete one entity model by its type.
      *
-     * @param entityType  The entity type.
-     * @param client      The client that will communicate with Elasticsearch.
-     * @param onComplete  The action to perform after deleting the entity model.
+     * @param entityType The entity type.
+     * @param client     The client that will communicate with Elasticsearch.
+     * @param onComplete The action to perform after deleting the entity model.
      */
     public static void deleteEntityModel(String entityType, NodeClient client, ActionListener<DeleteResponse> onComplete) {
         ensureIndex(client, new ActionListener<>() {

--- a/src/test/java/org/elasticsearch/plugin/zentity/ModelsActionTest.java
+++ b/src/test/java/org/elasticsearch/plugin/zentity/ModelsActionTest.java
@@ -1,0 +1,84 @@
+package org.elasticsearch.plugin.zentity;
+
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class ModelsActionTest {
+    private static Exception assertInvalidEntityType(String entityType) {
+        return ModelsAction.validateEntityType(entityType)
+                .map((ex) -> {
+                    assertTrue(ex.getMessage().contains("Invalid entity type [" + entityType + "]"));
+                    return ex;
+                })
+                .orElseGet(() -> {
+                    fail("failure expected");
+                    return null;
+                });
+    }
+
+    @Test
+    public void testInvalidEntityNameContainsAstrix() {
+        Exception ex = assertInvalidEntityType("selectivemploymentax*");
+        assertTrue(ex.getMessage().contains("must not contain the following characters"));
+        assertTrue(ex.getMessage().contains("*"));
+    }
+
+    @Test
+    public void testInvalidEntityNameContainsHash() {
+        Exception ex = assertInvalidEntityType("c#ke");
+        assertTrue(ex.getMessage().contains("must not contain '#'"));
+    }
+
+    @Test
+    public void testInvalidEntityNameContainsColon() {
+        Exception ex = assertInvalidEntityType("p:psi");
+        assertTrue(ex.getMessage().contains("must not contain ':'"));
+    }
+
+    @Test
+    public void testInvalidEntityNameStartsWith_() {
+        Exception ex = assertInvalidEntityType("_fanta");
+        assertTrue(ex.getMessage().contains("must not start with '_', '-', or '+'"));
+    }
+
+    @Test
+    public void testInvalidEntityNameStartsWithDash() {
+        Exception ex = assertInvalidEntityType("-fanta");
+        assertTrue(ex.getMessage().contains("must not start with '_', '-', or '+'"));
+    }
+
+    @Test
+    public void testInvalidEntityNameStartsWithPlus() {
+        Exception ex = assertInvalidEntityType("+fanta");
+        assertTrue(ex.getMessage().contains("must not start with '_', '-', or '+'"));
+    }
+
+    @Test
+    public void testInvalidEntityNameTooLong() {
+        String name = String.join("", Collections.nCopies(100, "sprite"));;
+        Exception ex = assertInvalidEntityType(name);
+        assertTrue(ex.getMessage().contains("entity type is too long"));
+    }
+
+    @Test
+    public void testInvalidEntityNameIsDot() {
+        Exception ex = assertInvalidEntityType(".");
+        assertTrue(ex.getMessage().contains("must not be '.' or '..'"));
+    }
+
+    @Test
+    public void testInvalidEntityNameIsDotDot() {
+        Exception ex = assertInvalidEntityType("..");
+        assertTrue(ex.getMessage().contains("must not be '.' or '..'"));
+    }
+
+    @Test
+    public void testInvalidEntityNameIsNotLowercase() {
+        Exception ex = assertInvalidEntityType("MELLO_yello");
+        assertTrue(ex.getMessage().contains("must be lowercase"));
+    }
+}


### PR DESCRIPTION
As per the [ES index naming requirements](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/indices-create-index.html#indices-create-api-path-params), this PR brings in validation to entity types, based on [the ES implementation](https://github.com/elastic/elasticsearch/blob/847b6f4b33b53421439209a4fe9607a8eac92e26/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java#L226-L255). This enforces the name requirements on create and update model methods, which is aligned with Elasticsearch's somewhat lenient handling of index names:

```
DELETE -someindex # returns 404 not found

GET -someindex # returns 404 not found

PUT -someindex  # returns 400 validation error
{}
```


Closes #58