### PR TITLE
feature-empty-models

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <zentity.website>https://zentity.io</zentity.website>
         <zentity.version>1.6.2</zentity.version>
         <!-- dependency versions -->
-        <elasticsearch.version>7.10.2</elasticsearch.version>
+        <elasticsearch.version>7.10.1</elasticsearch.version>
         <jackson.core.version>2.10.4</jackson.core.version>
         <jackson.databind.version>2.10.4</jackson.databind.version>
         <jdk.version>1.11</jdk.version>

--- a/src/main/java/io/zentity/model/Attribute.java
+++ b/src/main/java/io/zentity/model/Attribute.java
@@ -23,6 +23,7 @@ public class Attribute {
     private Map<String, String> params = new TreeMap<>();
     private Double score;
     private String type = "string";
+    private boolean validateRunnable = false;
 
     public Attribute(String name, JsonNode json) throws ValidationException, JsonProcessingException {
         validateName(name);
@@ -33,6 +34,20 @@ public class Attribute {
     public Attribute(String name, String json) throws ValidationException, IOException {
         validateName(name);
         this.name = name;
+        this.deserialize(json);
+    }
+
+    public Attribute(String name, JsonNode json, boolean validateRunnable) throws ValidationException, JsonProcessingException {
+        validateName(name);
+        this.name = name;
+        this.validateRunnable = validateRunnable;
+        this.deserialize(json);
+    }
+
+    public Attribute(String name, String json, boolean validateRunnable) throws ValidationException, IOException {
+        validateName(name);
+        this.name = name;
+        this.validateRunnable = validateRunnable;
         this.deserialize(json);
     }
 

--- a/src/main/java/io/zentity/model/Index.java
+++ b/src/main/java/io/zentity/model/Index.java
@@ -21,6 +21,7 @@ public class Index {
     private final String name;
     private Map<String, IndexField> fields;
     private Map<String, Map<String, IndexField>> attributeIndexFieldsMap = new TreeMap<>();
+    private boolean validateRunnable = false;
 
     public Index(String name, JsonNode json) throws ValidationException {
         validateName(name);
@@ -31,6 +32,20 @@ public class Index {
     public Index(String name, String json) throws ValidationException, IOException {
         validateName(name);
         this.name = name;
+        this.deserialize(json);
+    }
+
+    public Index(String name, JsonNode json, boolean validateRunnable) throws ValidationException {
+        validateName(name);
+        this.name = name;
+        this.validateRunnable = validateRunnable;
+        this.deserialize(json);
+    }
+
+    public Index(String name, String json, boolean validateRunnable) throws ValidationException, IOException {
+        validateName(name);
+        this.name = name;
+        this.validateRunnable = validateRunnable;
         this.deserialize(json);
     }
 
@@ -69,24 +84,30 @@ public class Index {
     private void validateField(String fieldName, JsonNode fieldObject) throws ValidationException {
         if (fieldName.equals(""))
             throw new ValidationException("'indices." + this.name + ".fields' has a field with an empty name.");
-        if (!fieldObject.isObject())
-            throw new ValidationException("'indices." + this.name + ".fields." + fieldName + "' must be an object.");
-        if (fieldObject.size() == 0)
-            throw new ValidationException("'indices." + this.name + ".fields." + fieldName + "' must not be empty.");
     }
 
     private void validateFields(JsonNode value) throws ValidationException {
         if (!value.isObject())
             throw new ValidationException("'indices." + this.name + ".fields' must be an object.");
-        if (value.size() == 0)
-            throw new ValidationException("'indices." + this.name + ".fields' must not be empty.");
+        if (this.validateRunnable) {
+            if (value.size() == 0) {
+                // Clarifying "in the entity model" because this exception likely will appear only for resolution requests,
+                // and the user might think that the message is referring to the input instead of the entity model.
+                throw new ValidationException("'indices." + this.name + ".fields' must not be empty in the entity model.");
+            }
+        }
     }
 
     private void validateObject(JsonNode object) throws ValidationException {
         if (!object.isObject())
             throw new ValidationException("'indices." + this.name + "' must be an object.");
-        if (object.size() == 0)
-            throw new ValidationException("'indices." + this.name + "' is empty.");
+        if (this.validateRunnable) {
+            if (object.size() == 0) {
+                // Clarifying "in the entity model" because this exception likely will appear only for resolution requests,
+                // and the user might think that the message is referring to the input instead of the entity model.
+                throw new ValidationException("'indices." + this.name + "' must not be empty in the entity model.");
+            }
+        }
     }
 
     /**

--- a/src/main/java/io/zentity/model/IndexField.java
+++ b/src/main/java/io/zentity/model/IndexField.java
@@ -25,6 +25,7 @@ public class IndexField {
     private String attribute;
     private String matcher;
     private Double quality;
+    private boolean validateRunnable = false;
 
     public IndexField(String index, String name, JsonNode json) throws ValidationException {
         validateName(name);
@@ -38,6 +39,24 @@ public class IndexField {
         validateName(name);
         this.index = index;
         this.name = name;
+        this.nameToPaths(name);
+        this.deserialize(json);
+    }
+
+    public IndexField(String index, String name, JsonNode json, boolean validateRunnable) throws ValidationException {
+        validateName(name);
+        this.index = index;
+        this.name = name;
+        this.validateRunnable = validateRunnable;
+        this.nameToPaths(name);
+        this.deserialize(json);
+    }
+
+    public IndexField(String index, String name, String json, boolean validateRunnable) throws ValidationException, IOException {
+        validateName(name);
+        this.index = index;
+        this.name = name;
+        this.validateRunnable = validateRunnable;
         this.nameToPaths(name);
         this.deserialize(json);
     }
@@ -99,30 +118,28 @@ public class IndexField {
 
     private void validateAttribute(JsonNode value) throws ValidationException {
         if (!value.isTextual())
-            throw new ValidationException("'indices." + this.index + "." + this.name + ".attribute' must be a string.");
+            throw new ValidationException("'indices." + this.index + ".fields." + this.name + ".attribute' must be a string.");
         if (Patterns.EMPTY_STRING.matcher(value.textValue()).matches())
-            throw new ValidationException("'indices." + this.index + "." + this.name + ".attribute' must not be empty.");
+            throw new ValidationException("'indices." + this.index + ".fields." + this.name + ".attribute' must not be empty.");
     }
 
     private void validateMatcher(JsonNode value) throws ValidationException {
-        if (!value.isTextual())
+        if (!value.isNull() && !value.isTextual())
             throw new ValidationException("'indices." + this.index + "." + this.name + ".matcher' must be a string.");
-        if (Patterns.EMPTY_STRING.matcher(value.textValue()).matches())
-            throw new ValidationException("'indices." + this.index + "." + this.name + ".matcher' must not be empty.");
+        if (value.isTextual() && Patterns.EMPTY_STRING.matcher(value.textValue()).matches())
+            throw new ValidationException("'indices." + this.index + ".fields." + this.name + ".matcher' must not be empty.");
     }
 
     private void validateObject(JsonNode object) throws ValidationException {
         if (!object.isObject())
-            throw new ValidationException("'indices." + this.index + "." + this.name + "' must be an object.");
-        if (object.size() == 0)
-            throw new ValidationException("'indices." + this.index + "." + this.name + "' is empty.");
+            throw new ValidationException("'indices." + this.index + ".fields." + this.name + "' must be an object.");
     }
 
     private void validateQuality(JsonNode value) throws ValidationException {
         if (!value.isNull() && !value.isFloatingPointNumber())
-            throw new ValidationException("'indices." + this.index + "." + this.name + ".quality' must be a floating point number.");
+            throw new ValidationException("'indices." + this.index + ".fields." + this.name + ".quality' must be a floating point number.");
         if (value.isFloatingPointNumber() && (value.floatValue() < 0.0 || value.floatValue() > 1.0))
-            throw new ValidationException("'indices." + this.index + "." + this.name + ".quality' must be in the range of 0.0 - 1.0.");
+            throw new ValidationException("'indices." + this.index + ".fields." + this.name + ".quality' must be in the range of 0.0 - 1.0.");
     }
 
     /**
@@ -144,7 +161,7 @@ public class IndexField {
         // Validate the existence of required fields.
         for (String field : REQUIRED_FIELDS)
             if (!json.has(field))
-                throw new ValidationException("'indices." + this.index + "." + this.name + "' is missing required field '" + field + "'.");
+                throw new ValidationException("'indices." + this.index + ".fields." + this.name + "' is missing required field '" + field + "'.");
 
         // Validate and hold the state of fields.
         Iterator<Map.Entry<String, JsonNode>> fields = json.fields();
@@ -163,7 +180,7 @@ public class IndexField {
                     this.quality(value);
                     break;
                 default:
-                    throw new ValidationException("'indices." + this.index + "." + this.name + "." + name + "' is not a recognized field.");
+                    throw new ValidationException("'indices." + this.index + ".fields." + this.name + "." + name + "' is not a recognized field.");
             }
         }
     }

--- a/src/main/java/io/zentity/model/Matcher.java
+++ b/src/main/java/io/zentity/model/Matcher.java
@@ -24,6 +24,7 @@ public class Matcher {
     private String clause;
     private Map<String, String> params = new TreeMap<>();
     private Double quality;
+    private boolean validateRunnable = false;
     private Map<String, Pattern> variables = new TreeMap<>();
 
     public Matcher(String name, JsonNode json) throws ValidationException, JsonProcessingException {
@@ -35,6 +36,20 @@ public class Matcher {
     public Matcher(String name, String json) throws ValidationException, IOException {
         validateName(name);
         this.name = name;
+        this.deserialize(json);
+    }
+
+    public Matcher(String name, JsonNode json, boolean validateRunnable) throws ValidationException, JsonProcessingException {
+        validateName(name);
+        this.name = name;
+        this.validateRunnable = validateRunnable;
+        this.deserialize(json);
+    }
+
+    public Matcher(String name, String json, boolean validateRunnable) throws ValidationException, IOException {
+        validateName(name);
+        this.name = name;
+        this.validateRunnable = validateRunnable;
         this.deserialize(json);
     }
 
@@ -96,14 +111,19 @@ public class Matcher {
         if (!value.isObject())
             throw new ValidationException("'matchers." + this.name + ".clause' must be an object.");
         if (value.size() == 0)
-            throw new ValidationException("'matchers." + this.name + ".clause' is empty.");
+            throw new ValidationException("'matchers." + this.name + ".clause' must not be empty.");
     }
 
     private void validateObject(JsonNode object) throws ValidationException {
         if (!object.isObject())
             throw new ValidationException("'matchers." + this.name + "' must be an object.");
-        if (object.size() == 0)
-            throw new ValidationException("'matchers." + this.name + "' is empty.");
+        if (this.validateRunnable) {
+            if (object.size() == 0) {
+                // Clarifying "in the entity model" because this exception likely will appear only for resolution requests,
+                // and the user might think that the message is referring to the input instead of the entity model.
+                throw new ValidationException("'matchers." + this.name + "' must not be empty in the entity model.");
+            }
+        }
     }
 
     private void validateQuality(JsonNode value) throws ValidationException {

--- a/src/main/java/io/zentity/model/Model.java
+++ b/src/main/java/io/zentity/model/Model.java
@@ -5,22 +5,35 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.zentity.common.Json;
 
 import java.io.IOException;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.*;
 
 public class Model {
+
+    public static final Set<String> REQUIRED_FIELDS = new TreeSet<>(
+            Arrays.asList("attributes", "resolvers", "matchers", "indices")
+    );
 
     private Map<String, Attribute> attributes = new TreeMap<>();
     private Map<String, Index> indices = new TreeMap<>();
     private Map<String, Matcher> matchers = new TreeMap<>();
     private Map<String, Resolver> resolvers = new TreeMap<>();
+    private boolean validateRunnable = false;
 
     public Model(JsonNode json) throws ValidationException, JsonProcessingException {
         this.deserialize(json);
     }
 
     public Model(String json) throws ValidationException, IOException {
+        this.deserialize(json);
+    }
+
+    public Model(JsonNode json, boolean validateRunnable) throws ValidationException, JsonProcessingException {
+        this.validateRunnable = validateRunnable;
+        this.deserialize(json);
+    }
+
+    public Model(String json, boolean validateRunnable) throws ValidationException, IOException {
+        this.validateRunnable = validateRunnable;
         this.deserialize(json);
     }
 
@@ -50,8 +63,13 @@ public class Model {
     private void validateField(JsonNode json, String field) throws ValidationException {
         if (!json.get(field).isObject())
             throw new ValidationException("'" + field + "' must be an object.");
-        if (json.get(field).size() == 0)
-            throw new ValidationException("'" + field + "' must not be empty.");
+        if (this.validateRunnable) {
+            if (json.get(field).size() == 0) {
+                // Clarifying "in the entity model" because this exception likely will appear only for resolution requests,
+                // and the user might think that the message is referring to the input instead of the entity model.
+                throw new ValidationException("'" + field + "' must not be empty in the entity model.");
+            }
+        }
     }
 
     /**
@@ -64,14 +82,26 @@ public class Model {
     private void validateObject(String field, JsonNode object) throws ValidationException {
         if (!object.isObject())
             throw new ValidationException("'" + field + "' must be an object.");
-        if (object.size() == 0)
-            throw new ValidationException("'" + field + "' is empty.");
+        if (this.validateRunnable) {
+            if (object.size() == 0) {
+                // Clarifying "in the entity model" because this exception likely will appear only for resolution requests,
+                // and the user might think that the message is referring to the input instead of the entity model.
+                throw new ValidationException("'" + field + "' must not be empty in the entity model.");
+            }
+        }
 
     }
 
     public void deserialize(JsonNode json) throws ValidationException, JsonProcessingException {
         if (!json.isObject())
             throw new ValidationException("Entity model must be an object.");
+
+        // Validate the existence of required fields.
+        for (String field : REQUIRED_FIELDS)
+            if (!json.has(field))
+                throw new ValidationException("Entity model is missing required field '" + field + "'.");
+
+        // Validate and hold the state of fields.
         Iterator<Map.Entry<String, JsonNode>> fields = json.fields();
         while (fields.hasNext()) {
             Map.Entry<String, JsonNode> field = fields.next();
@@ -86,16 +116,16 @@ public class Model {
                 JsonNode object = child.getValue();
                 switch (fieldName) {
                     case "attributes":
-                        this.attributes.put(name, new Attribute(name, object));
+                        this.attributes.put(name, new Attribute(name, object, this.validateRunnable));
                         break;
                     case "indices":
-                        this.indices.put(name, new Index(name, object));
+                        this.indices.put(name, new Index(name, object, this.validateRunnable));
                         break;
                     case "matchers":
-                        this.matchers.put(name, new Matcher(name, object));
+                        this.matchers.put(name, new Matcher(name, object, this.validateRunnable));
                         break;
                     case "resolvers":
-                        this.resolvers.put(name, new Resolver(name, object));
+                        this.resolvers.put(name, new Resolver(name, object, this.validateRunnable));
                         break;
                     default:
                         throw new ValidationException("'" + fieldName + "' is not a recognized field.");
@@ -103,14 +133,6 @@ public class Model {
             }
 
         }
-        if (this.attributes.size() == 0)
-            throw new ValidationException("'attributes' is missing.");
-        if (this.resolvers.size() == 0)
-            throw new ValidationException("'resolvers' is missing.");
-        if (this.matchers.size() == 0)
-            throw new ValidationException("'matchers' is missing.");
-        if (this.indices.size() == 0)
-            throw new ValidationException("'indices' is missing.");
     }
 
     public void deserialize(String json) throws ValidationException, IOException {

--- a/src/main/java/io/zentity/model/Resolver.java
+++ b/src/main/java/io/zentity/model/Resolver.java
@@ -19,6 +19,7 @@ public class Resolver {
 
     private final String name;
     private Set<String> attributes = new TreeSet<>();
+    private boolean validateRunnable = false;
     private int weight = 0;
 
     public Resolver(String name, JsonNode json) throws ValidationException {
@@ -30,6 +31,20 @@ public class Resolver {
     public Resolver(String name, String json) throws ValidationException, IOException {
         validateName(name);
         this.name = name;
+        this.deserialize(json);
+    }
+
+    public Resolver(String name, JsonNode json, boolean validateRunnable) throws ValidationException {
+        validateName(name);
+        this.name = name;
+        this.validateRunnable = validateRunnable;
+        this.deserialize(json);
+    }
+
+    public Resolver(String name, String json, boolean validateRunnable) throws ValidationException, IOException {
+        validateName(name);
+        this.name = name;
+        this.validateRunnable = validateRunnable;
         this.deserialize(json);
     }
 
@@ -65,7 +80,7 @@ public class Resolver {
         if (!value.isArray())
             throw new ValidationException("'resolvers." + this.name + ".attributes' must be an array of strings.");
         if (value.size() == 0)
-            throw new ValidationException("'resolvers." + this.name + ".attributes' is empty.");
+            throw new ValidationException("'resolvers." + this.name + ".attributes' must not be empty.");
         for (JsonNode attribute : value) {
             if (!attribute.isTextual())
                 throw new ValidationException("'resolvers." + this.name + ".attributes' must be an array of strings.");
@@ -76,15 +91,20 @@ public class Resolver {
     }
 
     private void validateWeight(JsonNode value) throws ValidationException {
-        if (!value.isInt())
+        if (!value.isNull() && !value.isInt())
             throw new ValidationException("'resolvers." + this.name + ".weight' must be an integer.");
     }
 
     private void validateObject(JsonNode object) throws ValidationException {
         if (!object.isObject())
             throw new ValidationException("'resolvers." + this.name + "' must be an object.");
-        if (object.size() == 0)
-            throw new ValidationException("'resolvers." + this.name + "' is empty.");
+        if (this.validateRunnable) {
+            if (object.size() == 0) {
+                // Clarifying "in the entity model" because this exception likely will appear only for resolution requests,
+                // and the user might think that the message is referring to the input instead of the entity model.
+                throw new ValidationException("'resolvers." + this.name + "' must not be empty in the entity model.");
+            }
+        }
     }
 
     /**

--- a/src/main/java/io/zentity/resolution/input/Input.java
+++ b/src/main/java/io/zentity/resolution/input/Input.java
@@ -219,6 +219,7 @@ public class Input {
 
     /**
      * Parse and validate the entity model from the 'model' field of the request body.
+     * The model must be runnable, meaning there are no missing fields required for resolution.
      *
      * @param requestBody The request body.
      * @return The parsed "model" field from the request body, or an object from ".zentity-models" index.
@@ -231,7 +232,7 @@ public class Input {
         JsonNode model = requestBody.get("model");
         if (!model.isObject())
             throw new ValidationException("Entity model must be an object.");
-        return new Model(model.toString());
+        return new Model(model.toString(), true);
     }
 
     /**
@@ -259,7 +260,7 @@ public class Input {
         if (!object.isObject())
             throw new ValidationException("'" + field + "' must be an object.");
         if (object.size() == 0)
-            throw new ValidationException("'" + field + "' is empty.");
+            throw new ValidationException("'" + field + "' must not be empty.");
 
     }
 

--- a/src/main/java/org/elasticsearch/plugin/zentity/ResolutionAction.java
+++ b/src/main/java/org/elasticsearch/plugin/zentity/ResolutionAction.java
@@ -157,7 +157,7 @@ public class ResolutionAction extends BaseRestHandler {
 
                                 // Run the entity resolution job using the input from the retrieved entity model.
                                 String model = response.getSourceAsString();
-                                Input input = new Input(body, new Model(model));
+                                Input input = new Input(body, new Model(model, true));
                                 job.input(input);
                                 runJob(channel, job);
 

--- a/src/test/java/io/zentity/model/AttributeTest.java
+++ b/src/test/java/io/zentity/model/AttributeTest.java
@@ -10,13 +10,14 @@ import java.io.IOException;
 
 public class AttributeTest {
 
-    public final static String VALID_OBJECT = "{\"type\":\"string\"}";
+    public final static String VALID_OBJECT = "{\"type\":\"string\",\"score\":0.5}";
 
     ////  "attributes"  ////////////////////////////////////////////////////////////////////////////////////////////////
 
     @Test
     public void testValid() throws Exception {
         new Attribute("attribute_name", VALID_OBJECT);
+        new Attribute("attribute_name", "{\"type\":\"string\"}");
         new Attribute("attribute_name", "{\"score\":0.5}");
         new Attribute("attribute_name", "{}");
     }
@@ -40,6 +41,22 @@ public class AttributeTest {
         new Attribute("attribute_name", "{\"score\":0.0}");
         new Attribute("attribute_name", "{\"score\":0.5}");
         new Attribute("attribute_name", "{\"score\":1.0}");
+        new Attribute("attribute_name", "{\"score\":null}");
+    }
+
+    /**
+     * Valid because the "score" field is optional.
+     */
+    @Test
+    public void testValidScoreMissing() throws Exception {
+        new Attribute("attribute_name", "{\"type\":\"string\"}");
+    }
+
+    /**
+     * Valid because the "score" field is optional.
+     */
+    @Test
+    public void testValidScoreTypeNull() throws Exception {
         new Attribute("attribute_name", "{\"score\":null}");
     }
 

--- a/src/test/java/io/zentity/model/IndexFieldTest.java
+++ b/src/test/java/io/zentity/model/IndexFieldTest.java
@@ -4,7 +4,7 @@ import org.junit.Test;
 
 public class IndexFieldTest {
 
-    public final static String VALID_OBJECT = "{\"attribute\":\"foo\",\"matcher\":\"bar\"}";
+    public final static String VALID_OBJECT = "{\"attribute\":\"foo\",\"matcher\":\"bar\",\"quality\":1.0}";
 
     ////  "indices".INDEX_NAME."fields"  ///////////////////////////////////////////////////////////////////////////////
 
@@ -15,7 +15,7 @@ public class IndexFieldTest {
 
     @Test(expected = ValidationException.class)
     public void testInvalidUnexpectedField() throws Exception {
-        new IndexField("index_name", "index_field_name", "{\"attribute\":\"foo\",\"matcher\":\"bar\",\"foo\":\"bar\"}");
+        new IndexField("index_name", "index_field_name", "{\"attribute\":\"foo\",\"matcher\":\"bar\",\"quality\":1.0,\"foo\":\"bar\"}");
     }
 
     ////  "indices".INDEX_NAME."fields".INDEX_FIELD_NAME  //////////////////////////////////////////////////////////////
@@ -69,9 +69,22 @@ public class IndexFieldTest {
 
     ////  "indices".INDEX_NAME."fields".INDEX_FIELD_NAME."matcher"  ////////////////////////////////////////////////////
 
+    /**
+     * Valid because matchers are optional for index fields.
+     * See: https://zentity.io/docs/advanced-usage/payload-attributes/
+     */
     @Test
     public void testValidMatcherMissing() throws Exception {
         new IndexField("index_name", "index_field_name", "{\"attribute\":\"foo\"}");
+    }
+
+    /**
+     * Valid because matchers are optional for index fields.
+     * See: https://zentity.io/docs/advanced-usage/payload-attributes/
+     */
+    @Test
+    public void testValidMatcherTypeNull() throws Exception {
+        new IndexField("index_name", "index_field_name", "{\"attribute\":\"foo\",\"matcher\":null}");
     }
 
     @Test(expected = ValidationException.class)
@@ -111,6 +124,22 @@ public class IndexFieldTest {
         new IndexField("index_name", "index_field_name", "{\"attribute\":\"foo\",\"quality\":0.0}");
         new IndexField("index_name", "index_field_name", "{\"attribute\":\"foo\",\"quality\":0.5}");
         new IndexField("index_name", "index_field_name", "{\"attribute\":\"foo\",\"quality\":1.0}");
+        new IndexField("index_name", "index_field_name", "{\"attribute\":\"foo\",\"quality\":null}");
+    }
+
+    /**
+     * Valid because the "quality" field is optional.
+     */
+    @Test
+    public void testValidQualityMissing() throws Exception {
+        new IndexField("index_name", "index_field_name", "{\"attribute\":\"foo\"}");
+    }
+
+    /**
+     * Valid because the "quality" field is optional.
+     */
+    @Test
+    public void testValidQualityTypeNull() throws Exception {
         new IndexField("index_name", "index_field_name", "{\"attribute\":\"foo\",\"quality\":null}");
     }
 

--- a/src/test/java/io/zentity/model/IndexTest.java
+++ b/src/test/java/io/zentity/model/IndexTest.java
@@ -32,9 +32,14 @@ public class IndexTest {
         new Index("index_name", "{}");
     }
 
-    @Test(expected = ValidationException.class)
-    public void testInvalidFieldsEmpty() throws Exception {
+    @Test
+    public void testValidFieldsEmpty() throws Exception {
         new Index("index_name", "{\"fields\":{}}");
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidFieldsEmptyRunnable() throws Exception {
+        new Index("index_name", "{\"fields\":{}}", true);
     }
 
     @Test(expected = ValidationException.class)

--- a/src/test/java/io/zentity/model/MatcherTest.java
+++ b/src/test/java/io/zentity/model/MatcherTest.java
@@ -73,6 +73,22 @@ public class MatcherTest {
         new Matcher("matcher_name", "{\"clause\":{\"match\":{\"{{ field }}\":\"{{ value }}\"}},\"quality\":null}");
     }
 
+    /**
+     * Valid because the "quality" field is optional.
+     */
+    @Test
+    public void testValidQualityMissing() throws Exception {
+        new Matcher("matcher_name", "{\"clause\":{\"match\":{\"{{ field }}\":\"{{ value }}\"}}}");
+    }
+
+    /**
+     * Valid because the "quality" field is optional.
+     */
+    @Test
+    public void testValidQualityTypeNull() throws Exception {
+        new Matcher("matcher_name", "{\"clause\":{\"match\":{\"{{ field }}\":\"{{ value }}\"}},\"quality\":null}");
+    }
+
     @Test(expected = ValidationException.class)
     public void testInvalidQualityTypeArray() throws Exception {
         new Matcher("matcher_name", "{\"clause\":{\"match\":{\"{{ field }}\":\"{{ value }}\"}},\"quality\":[]}");

--- a/src/test/java/io/zentity/model/ModelTest.java
+++ b/src/test/java/io/zentity/model/ModelTest.java
@@ -31,9 +31,10 @@ public class ModelTest {
 
     ////  model."attributes"  //////////////////////////////////////////////////////////////////////////////////////////
 
-    @Test(expected = ValidationException.class)
-    public void testInvalidAttributesMissing() throws Exception {
+    @Test
+    public void testValidAttributesEmpty() throws Exception {
         new Model("{\n" +
+                "  \"attributes\":{},\n" +
                 "  \"resolvers\":{\"resolver_name_a\":" + ResolverTest.VALID_OBJECT + "},\n" +
                 "  \"matchers\":{\"matcher_name\":" + MatcherTest.VALID_OBJECT + "},\n" +
                 "  \"indices\":{\"index_name_a\":" + IndexTest.VALID_OBJECT + "}\n" +
@@ -41,9 +42,18 @@ public class ModelTest {
     }
 
     @Test(expected = ValidationException.class)
-    public void testInvalidAttributesEmpty() throws Exception {
+    public void testInvalidAttributesEmptyRunnable() throws Exception {
         new Model("{\n" +
                 "  \"attributes\":{},\n" +
+                "  \"resolvers\":{\"resolver_name_a\":" + ResolverTest.VALID_OBJECT + "},\n" +
+                "  \"matchers\":{\"matcher_name\":" + MatcherTest.VALID_OBJECT + "},\n" +
+                "  \"indices\":{\"index_name_a\":" + IndexTest.VALID_OBJECT + "}\n" +
+                "}", true);
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidAttributesMissing() throws Exception {
+        new Model("{\n" +
                 "  \"resolvers\":{\"resolver_name_a\":" + ResolverTest.VALID_OBJECT + "},\n" +
                 "  \"matchers\":{\"matcher_name\":" + MatcherTest.VALID_OBJECT + "},\n" +
                 "  \"indices\":{\"index_name_a\":" + IndexTest.VALID_OBJECT + "}\n" +
@@ -172,20 +182,30 @@ public class ModelTest {
 
     ////  model."resolvers"  ///////////////////////////////////////////////////////////////////////////////////////////
 
-    @Test(expected = ValidationException.class)
-    public void testInvalidResolversMissing() throws Exception {
+    @Test
+    public void testValidResolversEmpty() throws Exception {
         new Model("{\n" +
                 "  \"attributes\":{\"attribute_name\":" + AttributeTest.VALID_OBJECT + "},\n" +
+                "  \"resolvers\":{},\n" +
                 "  \"matchers\":{\"matcher_name\":" + MatcherTest.VALID_OBJECT + "},\n" +
                 "  \"indices\":{\"index_name_a\":" + IndexTest.VALID_OBJECT + "}\n" +
                 "}");
     }
 
     @Test(expected = ValidationException.class)
-    public void testInvalidResolversEmpty() throws Exception {
+    public void testInvalidResolversEmptyRunnable() throws Exception {
         new Model("{\n" +
                 "  \"attributes\":{\"attribute_name\":" + AttributeTest.VALID_OBJECT + "},\n" +
                 "  \"resolvers\":{},\n" +
+                "  \"matchers\":{\"matcher_name\":" + MatcherTest.VALID_OBJECT + "},\n" +
+                "  \"indices\":{\"index_name_a\":" + IndexTest.VALID_OBJECT + "}\n" +
+                "}", true);
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidResolversMissing() throws Exception {
+        new Model("{\n" +
+                "  \"attributes\":{\"attribute_name\":" + AttributeTest.VALID_OBJECT + "},\n" +
                 "  \"matchers\":{\"matcher_name\":" + MatcherTest.VALID_OBJECT + "},\n" +
                 "  \"indices\":{\"index_name_a\":" + IndexTest.VALID_OBJECT + "}\n" +
                 "}");
@@ -313,21 +333,31 @@ public class ModelTest {
 
     ////  model."matchers"  ////////////////////////////////////////////////////////////////////////////////////////////
 
-    @Test(expected = ValidationException.class)
-    public void testInvalidMatchersMissing() throws Exception {
+    @Test
+    public void testValidMatchersEmpty() throws Exception {
         new Model("{\n" +
                 "  \"attributes\":{\"attribute_name\":" + AttributeTest.VALID_OBJECT + "},\n" +
                 "  \"resolvers\":{\"resolver_name_a\":" + ResolverTest.VALID_OBJECT + "},\n" +
+                "  \"matchers\":{},\n" +
                 "  \"indices\":{\"index_name_a\":" + IndexTest.VALID_OBJECT + "}\n" +
                 "}");
     }
 
     @Test(expected = ValidationException.class)
-    public void testInvalidMatchersEmpty() throws Exception {
+    public void testInvalidMatchersEmptyRunnable() throws Exception {
         new Model("{\n" +
                 "  \"attributes\":{\"attribute_name\":" + AttributeTest.VALID_OBJECT + "},\n" +
                 "  \"resolvers\":{\"resolver_name_a\":" + ResolverTest.VALID_OBJECT + "},\n" +
                 "  \"matchers\":{},\n" +
+                "  \"indices\":{\"index_name_a\":" + IndexTest.VALID_OBJECT + "}\n" +
+                "}", true);
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidMatchersMissing() throws Exception {
+        new Model("{\n" +
+                "  \"attributes\":{\"attribute_name\":" + AttributeTest.VALID_OBJECT + "},\n" +
+                "  \"resolvers\":{\"resolver_name_a\":" + ResolverTest.VALID_OBJECT + "},\n" +
                 "  \"indices\":{\"index_name_a\":" + IndexTest.VALID_OBJECT + "}\n" +
                 "}");
     }
@@ -454,22 +484,62 @@ public class ModelTest {
 
     ////  model."indices"  /////////////////////////////////////////////////////////////////////////////////////////////
 
+    @Test
+    public void testValidIndicesEmpty() throws Exception {
+        new Model("{\n" +
+                "  \"attributes\":{\"attribute_name\":" + AttributeTest.VALID_OBJECT + "},\n" +
+                "  \"resolvers\":{\"resolver_name_a\":" + ResolverTest.VALID_OBJECT + "},\n" +
+                "  \"matchers\":{\"matcher_name\":" + MatcherTest.VALID_OBJECT + "},\n" +
+                "  \"indices\":{}\n" +
+                "}");
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidIndicesEmptyRunnable() throws Exception {
+        new Model("{\n" +
+                "  \"attributes\":{\"attribute_name\":" + AttributeTest.VALID_OBJECT + "},\n" +
+                "  \"resolvers\":{\"resolver_name_a\":" + ResolverTest.VALID_OBJECT + "},\n" +
+                "  \"matchers\":{\"matcher_name\":" + MatcherTest.VALID_OBJECT + "},\n" +
+                "  \"indices\":{}\n" +
+                "}", true);
+    }
+
+    @Test
+    public void testValidIndexEmpty() throws Exception {
+        new Model("{\n" +
+                "  \"attributes\":{\"attribute_name\":" + AttributeTest.VALID_OBJECT + "},\n" +
+                "  \"resolvers\":{\"resolver_name_a\":" + ResolverTest.VALID_OBJECT + "},\n" +
+                "  \"matchers\":{\"matcher_name\":" + MatcherTest.VALID_OBJECT + "},\n" +
+                "  \"indices\": {\"index_name\":{\"fields\":{}}}\n" +
+                "}");
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidIndexEmptyRunnable() throws Exception {
+        new Model("{\n" +
+                "  \"attributes\":{\"attribute_name\":" + AttributeTest.VALID_OBJECT + "},\n" +
+                "  \"resolvers\":{\"resolver_name_a\":" + ResolverTest.VALID_OBJECT + "},\n" +
+                "  \"matchers\":{\"matcher_name\":" + MatcherTest.VALID_OBJECT + "},\n" +
+                "  \"indices\": {\"index_name\":{\"fields\":{}}}\n" +
+                "}", true);
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidIndexFieldEmpty() throws Exception {
+        new Model("{\n" +
+                "  \"attributes\":{\"attribute_name\":" + AttributeTest.VALID_OBJECT + "},\n" +
+                "  \"resolvers\":{\"resolver_name_a\":" + ResolverTest.VALID_OBJECT + "},\n" +
+                "  \"matchers\":{\"matcher_name\":" + MatcherTest.VALID_OBJECT + "},\n" +
+                "  \"indices\": {\"index_name\":{\"fields\":{\"index_field_name\":{}}}}\n" +
+                "}");
+    }
+
     @Test(expected = ValidationException.class)
     public void testInvalidIndicesMissing() throws Exception {
         new Model("{\n" +
                 "  \"attributes\":{\"attribute_name\":" + AttributeTest.VALID_OBJECT + "},\n" +
                 "  \"resolvers\":{\"resolver_name_a\":" + ResolverTest.VALID_OBJECT + "},\n" +
                 "  \"matchers\":{\"matcher_name\":" + MatcherTest.VALID_OBJECT + "}\n" +
-                "}");
-    }
-
-    @Test(expected = ValidationException.class)
-    public void testInvalidIndicesEmpty() throws Exception {
-        new Model("{\n" +
-                "  \"attributes\":{\"attribute_name\":" + AttributeTest.VALID_OBJECT + "},\n" +
-                "  \"resolvers\":{\"resolver_name_a\":" + ResolverTest.VALID_OBJECT + "},\n" +
-                "  \"matchers\":{\"matcher_name\":" + MatcherTest.VALID_OBJECT + "},\n" +
-                "  \"indices\":{}\n" +
                 "}");
     }
 
@@ -530,16 +600,6 @@ public class ModelTest {
                 "  \"resolvers\":{\"resolver_name_a\":" + ResolverTest.VALID_OBJECT + "},\n" +
                 "  \"matchers\":{\"matcher_name\":" + MatcherTest.VALID_OBJECT + "},\n" +
                 "  \"indices\":\"foobar\"\n" +
-                "}");
-    }
-
-    @Test(expected = ValidationException.class)
-    public void testInvalidIndexEmpty() throws Exception {
-        new Model("{\n" +
-                "  \"attributes\":{\"attribute_name\":" + AttributeTest.VALID_OBJECT + "},\n" +
-                "  \"resolvers\":{\"resolver_name_a\":" + ResolverTest.VALID_OBJECT + "},\n" +
-                "  \"matchers\":{\"matcher_name\":" + MatcherTest.VALID_OBJECT + "},\n" +
-                "  \"indices\": {}\n" +
                 "}");
     }
 

--- a/src/test/java/io/zentity/model/ResolverTest.java
+++ b/src/test/java/io/zentity/model/ResolverTest.java
@@ -110,6 +110,30 @@ public class ResolverTest {
 
     ////  "resolvers".RESOLVER_NAME."weight"  //////////////////////////////////////////////////////////////////////
 
+    @Test
+    public void testValidWeightValue() throws Exception {
+        new Resolver("resolver_name", "{\"attributes\":[\"attribute_a\"],\"weight\":0}");
+        new Resolver("resolver_name", "{\"attributes\":[\"attribute_a\"],\"weight\":1}");
+        new Resolver("resolver_name", "{\"attributes\":[\"attribute_a\"],\"weight\":-1}");
+        new Resolver("resolver_name", "{\"attributes\":[\"attribute_a\"],\"weight\":null}");
+    }
+
+    /**
+     * Valid because the "weight" field is optional.
+     */
+    @Test
+    public void testValidWeightMissing() throws Exception {
+        new Resolver("resolver_name", "{\"attributes\":[\"attribute_a\"]}");
+    }
+
+    /**
+     * Valid because the "weight" field is optional.
+     */
+    @Test
+    public void testValidWeightTypeNull() throws Exception {
+        new Resolver("resolver_name", "{\"attributes\":[\"attribute_a\"],\"weight\":null}");
+    }
+
     @Test(expected = ValidationException.class)
     public void testInvalidWeightTypeArray() throws Exception {
         new Resolver("resolver_name", "{\"attributes\":[\"attribute_a\"],\"weight\":[]}");
@@ -123,11 +147,6 @@ public class ResolverTest {
     @Test(expected = ValidationException.class)
     public void testInvalidWeightTypeFloat() throws Exception {
         new Resolver("resolver_name", "{\"attributes\":[\"attribute_a\"],\"weight\":1.0}");
-    }
-
-    @Test(expected = ValidationException.class)
-    public void testInvalidWeightTypeNull() throws Exception {
-        new Resolver("resolver_name", "{\"attributes\":[\"attribute_a\"],\"weight\":null}");
     }
 
     @Test(expected = ValidationException.class)

--- a/src/test/resources/TestEntityModelA.json
+++ b/src/test/resources/TestEntityModelA.json
@@ -478,6 +478,13 @@
         "unused": {
           "attribute": "attribute_unused",
           "matcher": "matcher_b"
+        },
+        "unused_matcher": {
+          "attribute": "attribute_unused"
+        },
+        "unused_matcher_null": {
+          "attribute": "attribute_unused",
+          "matcher": null
         }
       }
     }

--- a/src/test/resources/TestEntityModelB.json
+++ b/src/test/resources/TestEntityModelB.json
@@ -97,6 +97,13 @@
         "unused": {
           "attribute": "attribute_unused",
           "matcher": "matcher_b"
+        },
+        "unused_matcher": {
+          "attribute": "attribute_unused"
+        },
+        "unused_matcher_null": {
+          "attribute": "attribute_unused",
+          "matcher": null
         }
       }
     }

--- a/src/test/resources/TestIndex.json
+++ b/src/test/resources/TestIndex.json
@@ -1,7 +1,7 @@
 {
   "settings": {
     "number_of_shards": 1,
-    "number_of_replicas": 0,
+    "number_of_replicas": 2,
     "analysis": {
       "filter": {
         "strip_punct": {

--- a/src/test/resources/TestIndexArrays.json
+++ b/src/test/resources/TestIndexArrays.json
@@ -1,7 +1,7 @@
 {
   "settings": {
     "number_of_shards": 1,
-    "number_of_replicas": 0
+    "number_of_replicas": 2
   },
   "mappings" : {
     "properties" : {

--- a/src/test/resources/TestIndexArraysElasticsearch6.json
+++ b/src/test/resources/TestIndexArraysElasticsearch6.json
@@ -1,7 +1,7 @@
 {
   "settings": {
     "number_of_shards": 1,
-    "number_of_replicas": 0
+    "number_of_replicas": 2
   },
   "mappings" : {
     "doc": {

--- a/src/test/resources/TestIndexElasticsearch6.json
+++ b/src/test/resources/TestIndexElasticsearch6.json
@@ -1,7 +1,7 @@
 {
   "settings": {
     "number_of_shards": 1,
-    "number_of_replicas": 0,
+    "number_of_replicas": 2,
     "analysis": {
       "filter": {
         "strip_punct": {


### PR DESCRIPTION
The Models API now allows entity models to be saved with empty objects for "attributes", "matchers", "resolvers", "indices", and "indices".INDEX_NAME."fields". The Resolution API still requires those objects to be not empty. This more lenient validation of the Models API will allow users to incrementally build out entity models through a user interface until they are ready to use them.