### PR TITLE
feature-attribute-nesting

### DIFF
--- a/src/main/java/io/zentity/model/Attribute.java
+++ b/src/main/java/io/zentity/model/Attribute.java
@@ -20,6 +20,7 @@ public class Attribute {
     );
 
     private final String name;
+    private String[] nameFields;
     private Map<String, String> params = new TreeMap<>();
     private Double score;
     private String type = "string";
@@ -28,18 +29,21 @@ public class Attribute {
     public Attribute(String name, JsonNode json) throws ValidationException, JsonProcessingException {
         validateName(name);
         this.name = name;
+        this.nameFields = this.parseNameFields(name);
         this.deserialize(json);
     }
 
     public Attribute(String name, String json) throws ValidationException, IOException {
         validateName(name);
         this.name = name;
+        this.nameFields = this.parseNameFields(name);
         this.deserialize(json);
     }
 
     public Attribute(String name, JsonNode json, boolean validateRunnable) throws ValidationException, JsonProcessingException {
         validateName(name);
         this.name = name;
+        this.nameFields = this.parseNameFields(name);
         this.validateRunnable = validateRunnable;
         this.deserialize(json);
     }
@@ -47,12 +51,17 @@ public class Attribute {
     public Attribute(String name, String json, boolean validateRunnable) throws ValidationException, IOException {
         validateName(name);
         this.name = name;
+        this.nameFields = this.parseNameFields(name);
         this.validateRunnable = validateRunnable;
         this.deserialize(json);
     }
 
     public String name() {
         return this.name;
+    }
+
+    public String[] nameFields() {
+        return this.nameFields;
     }
 
     public Map<String, String> params() {
@@ -77,10 +86,24 @@ public class Attribute {
         this.type = value.textValue();
     }
 
+    /**
+     *
+     * @param name The name of the attribute.
+     * @return
+     */
+    private String[] parseNameFields(String name) throws ValidationException {
+        String[] nameFields = Patterns.PERIOD.split(name, -1);
+        this.validateNameFields(nameFields);
+        return nameFields;
+    }
+
     private void validateName(String value) throws ValidationException {
         Model.validateStrictName(value);
-        if (Patterns.EMPTY_STRING.matcher(value).matches())
-            throw new ValidationException("'attributes' has an attribute with empty name.");
+    }
+
+    private void validateNameFields(String[] nameFields) throws ValidationException {
+        for (String nameField : nameFields)
+            Model.validateStrictName(nameField);
     }
 
     private void validateScore(JsonNode value) throws ValidationException {

--- a/src/main/java/io/zentity/model/Matcher.java
+++ b/src/main/java/io/zentity/model/Matcher.java
@@ -104,8 +104,6 @@ public class Matcher {
 
     private void validateName(String value) throws ValidationException {
         Model.validateStrictName(value);
-        if (Patterns.EMPTY_STRING.matcher(value).matches())
-            throw new ValidationException("'matchers' field has a matcher with an empty name.");
     }
 
     private void validateClause(JsonNode value) throws ValidationException {

--- a/src/main/java/io/zentity/model/Model.java
+++ b/src/main/java/io/zentity/model/Model.java
@@ -121,16 +121,8 @@ public class Model {
                 if (a == b)
                     continue;
                 String nameB = names.get(b) + ".";
-                List<String> conflict = new ArrayList<>();
-                if (nameA.startsWith(nameB)) {
-                    conflict.add(names.get(b));
-                    conflict.add(names.get(a));
-                } else if (nameB.startsWith(nameA)) {
-                    conflict.add(names.get(a));
-                    conflict.add(names.get(b));
-                }
-                if (!conflict.isEmpty())
-                    throw new ValidationException("'attributes." + conflict.get(0) + "' is invalid because 'attributes." + conflict.get(1) + "' overrides its name.");
+                if (nameA.startsWith(nameB))
+                   throw new ValidationException("'attributes." + names.get(b) + "' is invalid because 'attributes." + names.get(a) + "' overrides its name.");
             }
         }
     }

--- a/src/main/java/io/zentity/model/Model.java
+++ b/src/main/java/io/zentity/model/Model.java
@@ -3,6 +3,7 @@ package io.zentity.model;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.zentity.common.Json;
+import io.zentity.common.Patterns;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.Strings;
 
@@ -70,6 +71,8 @@ public class Model {
      */
     public static void validateStrictName(String name) throws ValidationException {
         BiFunction<String, String, String> msg = (invalidName, description) -> "Invalid name [" + invalidName + "], " + description;
+        if (Patterns.EMPTY_STRING.matcher(name).matches())
+            throw new ValidationException(msg.apply(name, "must not be empty"));
         if (!Strings.validFileName(name))
             throw new ValidationException(msg.apply(name, "must not contain the following characters: " + Strings.INVALID_FILENAME_CHARS));
         if (name.contains("#"))

--- a/src/main/java/io/zentity/model/Resolver.java
+++ b/src/main/java/io/zentity/model/Resolver.java
@@ -73,8 +73,6 @@ public class Resolver {
 
     private void validateName(String value) throws ValidationException {
         Model.validateStrictName(value);
-        if (Patterns.EMPTY_STRING.matcher(value).matches())
-            throw new ValidationException("'resolvers' has a resolver with an empty name.");
     }
 
     private void validateAttributes(JsonNode value) throws ValidationException {

--- a/src/test/java/io/zentity/model/AttributeTest.java
+++ b/src/test/java/io/zentity/model/AttributeTest.java
@@ -32,6 +32,11 @@ public class AttributeTest {
 
     @Test(expected = ValidationException.class)
     public void testInvalidNameEmpty() throws Exception {
+        new Attribute("", VALID_OBJECT);
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidNameEmptyWhitespace() throws Exception {
         new Attribute(" ", VALID_OBJECT);
     }
 
@@ -85,11 +90,45 @@ public class AttributeTest {
         new Attribute("MELLO_yello", VALID_OBJECT);
     }
 
+    @Test(expected = ValidationException.class)
+    public void testInvalidNameFieldEmptyFirst() throws Exception {
+        new Attribute(".hello", VALID_OBJECT);
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidNameFieldEmptyLast() throws Exception {
+        new Attribute("hello.", VALID_OBJECT);
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidNameFieldEmptyMiddle() throws Exception {
+        new Attribute("hello..world", VALID_OBJECT);
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidNameFieldEmptyWhitespace() throws Exception {
+        new Attribute("hello. ", VALID_OBJECT);
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidNameFieldStartsWithUnderscore() throws Exception {
+        new Attribute("hello._fanta", VALID_OBJECT);
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidNameFieldStartsWithDash() throws Exception {
+        new Attribute("hello.-fanta", VALID_OBJECT);
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidNameFieldStartsWithPlus() throws Exception {
+        new Attribute("hello.+fanta", VALID_OBJECT);
+    }
+
     @Test
     public void testValidNames() throws Exception {
         new Attribute("hello", VALID_OBJECT);
-        new Attribute(".hello", VALID_OBJECT);
-        new Attribute("..hello", VALID_OBJECT);
+        new Attribute("hello.world", VALID_OBJECT);
         new Attribute("hello_world", VALID_OBJECT);
         new Attribute("hello-world", VALID_OBJECT);
         new Attribute("hello+world", VALID_OBJECT);

--- a/src/test/java/io/zentity/model/MatcherTest.java
+++ b/src/test/java/io/zentity/model/MatcherTest.java
@@ -83,6 +83,7 @@ public class MatcherTest {
         new Matcher("hello", VALID_OBJECT);
         new Matcher(".hello", VALID_OBJECT);
         new Matcher("..hello", VALID_OBJECT);
+        new Matcher("hello.world", VALID_OBJECT);
         new Matcher("hello_world", VALID_OBJECT);
         new Matcher("hello-world", VALID_OBJECT);
         new Matcher("hello+world", VALID_OBJECT);

--- a/src/test/java/io/zentity/model/ModelTest.java
+++ b/src/test/java/io/zentity/model/ModelTest.java
@@ -134,6 +134,22 @@ public class ModelTest {
                 "}");
     }
 
+    @Test
+    public void testValidAttributeNesting() throws Exception {
+        new Model("{\n" +
+                "  \"attributes\":{\"a.b\":{},\"a.c\":{},\"d\":{}},\n" +
+                "  \"resolvers\":{\"resolver_name_a\":" + ResolverTest.VALID_OBJECT + "},\n" +
+                "  \"matchers\":{\"matcher_name\":" + MatcherTest.VALID_OBJECT + "},\n" +
+                "  \"indices\":{\"index_name_a\":" + IndexTest.VALID_OBJECT + "}\n" +
+                "}");
+        new Model("{\n" +
+                "  \"attributes\":{\"a.b\":{},\"a.c\":{},\"a.d.a\":{},\"a.d.b\":{},\"a.d.c\":{}},\n" +
+                "  \"resolvers\":{\"resolver_name_a\":" + ResolverTest.VALID_OBJECT + "},\n" +
+                "  \"matchers\":{\"matcher_name\":" + MatcherTest.VALID_OBJECT + "},\n" +
+                "  \"indices\":{\"index_name_a\":" + IndexTest.VALID_OBJECT + "}\n" +
+                "}");
+    }
+
     @Test(expected = ValidationException.class)
     public void testInvalidAttributesEmptyRunnable() throws Exception {
         new Model("{\n" +
@@ -267,6 +283,16 @@ public class ModelTest {
     public void testInvalidAttributeTypeString() throws Exception {
         new Model("{\n" +
                 "  \"attributes\":{\"attribute_name\":\"foobar\"},\n" +
+                "  \"resolvers\":{\"resolver_name_a\":" + ResolverTest.VALID_OBJECT + "},\n" +
+                "  \"matchers\":{\"matcher_name\":" + MatcherTest.VALID_OBJECT + "},\n" +
+                "  \"indices\":{\"index_name_a\":" + IndexTest.VALID_OBJECT + "}\n" +
+                "}");
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testInvalidAttributeNestingConflict() throws Exception {
+        new Model("{\n" +
+                "  \"attributes\":{\"attribute_name\":{},\"attribute_name.nested\":" + AttributeTest.VALID_OBJECT + "},\n" +
                 "  \"resolvers\":{\"resolver_name_a\":" + ResolverTest.VALID_OBJECT + "},\n" +
                 "  \"matchers\":{\"matcher_name\":" + MatcherTest.VALID_OBJECT + "},\n" +
                 "  \"indices\":{\"index_name_a\":" + IndexTest.VALID_OBJECT + "}\n" +

--- a/src/test/java/io/zentity/model/ResolverTest.java
+++ b/src/test/java/io/zentity/model/ResolverTest.java
@@ -86,6 +86,7 @@ public class ResolverTest {
         new Resolver("hello", VALID_OBJECT);
         new Resolver(".hello", VALID_OBJECT);
         new Resolver("..hello", VALID_OBJECT);
+        new Resolver("hello.world", VALID_OBJECT);
         new Resolver("hello_world", VALID_OBJECT);
         new Resolver("hello-world", VALID_OBJECT);
         new Resolver("hello+world", VALID_OBJECT);

--- a/src/test/java/org/elasticsearch/plugin/zentity/ResolutionActionIT.java
+++ b/src/test/java/org/elasticsearch/plugin/zentity/ResolutionActionIT.java
@@ -54,7 +54,7 @@ public class ResolutionActionIT extends AbstractIT {
     public static final StringEntity TEST_PAYLOAD_JOB_EXPLANATION = new StringEntity("{\n" +
             "  \"attributes\": {\n" +
             "    \"attribute_a\": [ \"a_00\" ],\n" +
-            "    \"attribute_type_date\": {" +
+            "    \"attribute_type.date\": {" +
             "      \"values\": [ \"1999-12-31T23:59:57.0000\" ],\n" +
             "      \"params\": {\n" +
             "        \"format\" : \"yyyy-MM-dd'T'HH:mm:ss.0000\",\n" +
@@ -71,7 +71,7 @@ public class ResolutionActionIT extends AbstractIT {
 
     public static final StringEntity TEST_PAYLOAD_JOB_EXPLANATION_TERMS = new StringEntity("{\n" +
             "  \"attributes\": {" +
-            "    \"attribute_type_date\": {" +
+            "    \"attribute_type.date\": {" +
             "      \"params\": {\n" +
             "        \"format\" : \"yyyy-MM-dd'T'HH:mm:ss.0000\",\n" +
             "        \"window\" : \"1d\"\n" +
@@ -138,7 +138,7 @@ public class ResolutionActionIT extends AbstractIT {
             "}", ContentType.APPLICATION_JSON);
 
     public static final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_BOOLEAN_TRUE = new StringEntity("{\n" +
-            "  \"attributes\": { \"attribute_type_boolean\": [ true ] },\n" +
+            "  \"attributes\": { \"attribute_type.boolean\": [ true ] },\n" +
             "  \"scope\": {\n" +
             "    \"include\": {\n" +
             "      \"indices\": [ \"zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_boolean\" ]\n" +
@@ -158,7 +158,7 @@ public class ResolutionActionIT extends AbstractIT {
     public static final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_DATE = new StringEntity("{\n" +
             "  \"attributes\": {\n" +
             "    \"attribute_d\": { \"values\": [ \"d_00\" ] },\n" +
-            "    \"attribute_type_date\": {\n" +
+            "    \"attribute_type.date\": {\n" +
             "      \"values\": [ \"2000-01-01 00:00:00\" ],\n" +
             "      \"params\": { \"format\": \"yyyy-MM-dd HH:mm:ss\", \"window\": \"1s\" }\n" +
             "    }\n" +
@@ -172,7 +172,7 @@ public class ResolutionActionIT extends AbstractIT {
 
     public static final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_DATE_TERMS = new StringEntity("{\n" +
             "  \"attributes\": {\n" +
-            "    \"attribute_type_date\": {\n" +
+            "    \"attribute_type.date\": {\n" +
             "      \"params\": { \"format\": \"yyyy-MM-dd HH:mm:ss\", \"window\": \"1s\" }\n" +
             "    }\n" +
             "  },\n" +
@@ -185,7 +185,7 @@ public class ResolutionActionIT extends AbstractIT {
             "}", ContentType.APPLICATION_JSON);
 
     public static final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_BOOLEAN_FALSE = new StringEntity("{\n" +
-            "  \"attributes\": { \"attribute_type_boolean\": [ false ] },\n" +
+            "  \"attributes\": { \"attribute_type.boolean\": [ false ] },\n" +
             "  \"scope\": {\n" +
             "    \"include\": {\n" +
             "      \"indices\": [ \"zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_boolean\" ]\n" +
@@ -203,7 +203,7 @@ public class ResolutionActionIT extends AbstractIT {
             "}", ContentType.APPLICATION_JSON);
 
     public static final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_DOUBLE_POSITIVE = new StringEntity("{\n" +
-            "  \"attributes\": { \"attribute_type_double\": [ 3.141592653589793 ] },\n" +
+            "  \"attributes\": { \"attribute_type.number.double\": [ 3.141592653589793 ] },\n" +
             "  \"scope\": {\n" +
             "    \"include\": {\n" +
             "      \"indices\": [ \"zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_double\" ]\n" +
@@ -221,7 +221,7 @@ public class ResolutionActionIT extends AbstractIT {
             "}", ContentType.APPLICATION_JSON);
 
     public static final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_DOUBLE_NEGATIVE = new StringEntity("{\n" +
-            "  \"attributes\": { \"attribute_type_double\": [ -3.141592653589793 ] },\n" +
+            "  \"attributes\": { \"attribute_type.number.double\": [ -3.141592653589793 ] },\n" +
             "  \"scope\": {\n" +
             "    \"include\": {\n" +
             "      \"indices\": [ \"zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_double\" ]\n" +
@@ -239,7 +239,7 @@ public class ResolutionActionIT extends AbstractIT {
             "}", ContentType.APPLICATION_JSON);
 
     public static final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_FLOAT_POSITIVE = new StringEntity("{\n" +
-            "  \"attributes\": { \"attribute_type_float\": [ 1.0 ] },\n" +
+            "  \"attributes\": { \"attribute_type.number.float\": [ 1.0 ] },\n" +
             "  \"scope\": {\n" +
             "    \"include\": {\n" +
             "      \"indices\": [ \"zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_float\" ]\n" +
@@ -257,7 +257,7 @@ public class ResolutionActionIT extends AbstractIT {
             "}", ContentType.APPLICATION_JSON);
 
     public static final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_FLOAT_NEGATIVE = new StringEntity("{\n" +
-            "  \"attributes\": { \"attribute_type_float\": [ -1.0 ] },\n" +
+            "  \"attributes\": { \"attribute_type.number.float\": [ -1.0 ] },\n" +
             "  \"scope\": {\n" +
             "    \"include\": {\n" +
             "      \"indices\": [ \"zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_float\" ]\n" +
@@ -275,7 +275,7 @@ public class ResolutionActionIT extends AbstractIT {
             "}", ContentType.APPLICATION_JSON);
 
     public static final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_INTEGER_POSITIVE = new StringEntity("{\n" +
-            "  \"attributes\": { \"attribute_type_integer\": [ 1 ] },\n" +
+            "  \"attributes\": { \"attribute_type.number.integer\": [ 1 ] },\n" +
             "  \"scope\": {\n" +
             "    \"include\": {\n" +
             "      \"indices\": [ \"zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_integer\" ]\n" +
@@ -293,7 +293,7 @@ public class ResolutionActionIT extends AbstractIT {
             "}", ContentType.APPLICATION_JSON);
 
     public static final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_INTEGER_NEGATIVE = new StringEntity("{\n" +
-            "  \"attributes\": { \"attribute_type_integer\": [ -1 ] },\n" +
+            "  \"attributes\": { \"attribute_type.number.integer\": [ -1 ] },\n" +
             "  \"scope\": {\n" +
             "    \"include\": {\n" +
             "      \"indices\": [ \"zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_integer\" ]\n" +
@@ -311,7 +311,7 @@ public class ResolutionActionIT extends AbstractIT {
             "}", ContentType.APPLICATION_JSON);
 
     public static final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_LONG_POSITIVE = new StringEntity("{\n" +
-            "  \"attributes\": { \"attribute_type_long\": [ 922337203685477 ] },\n" +
+            "  \"attributes\": { \"attribute_type.number.long\": [ 922337203685477 ] },\n" +
             "  \"scope\": {\n" +
             "    \"include\": {\n" +
             "      \"indices\": [ \"zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_long\" ]\n" +
@@ -329,7 +329,7 @@ public class ResolutionActionIT extends AbstractIT {
             "}", ContentType.APPLICATION_JSON);
 
     public static final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_NUMBER_LONG_NEGATIVE = new StringEntity("{\n" +
-            "  \"attributes\": { \"attribute_type_long\": [ -922337203685477 ] },\n" +
+            "  \"attributes\": { \"attribute_type.number.long\": [ -922337203685477 ] },\n" +
             "  \"scope\": {\n" +
             "    \"include\": {\n" +
             "      \"indices\": [ \"zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_long\" ]\n" +
@@ -347,7 +347,7 @@ public class ResolutionActionIT extends AbstractIT {
             "}", ContentType.APPLICATION_JSON);
 
     public static final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_STRING_A = new StringEntity("{\n" +
-            "  \"attributes\": { \"attribute_type_string\": [ \"a\" ] },\n" +
+            "  \"attributes\": { \"attribute_type.string.normal\": [ \"a\" ] },\n" +
             "  \"scope\": {\n" +
             "    \"include\": {\n" +
             "      \"indices\": [ \"zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_string\" ]\n" +
@@ -365,7 +365,7 @@ public class ResolutionActionIT extends AbstractIT {
             "}", ContentType.APPLICATION_JSON);
 
     public static final StringEntity TEST_PAYLOAD_JOB_DATA_TYPES_STRING_B = new StringEntity("{\n" +
-            "  \"attributes\": { \"attribute_type_string\": [ \"b\" ] },\n" +
+            "  \"attributes\": { \"attribute_type.string.normal\": [ \"b\" ] },\n" +
             "  \"scope\": {\n" +
             "    \"include\": {\n" +
             "      \"indices\": [ \"zentity_test_index_a\" ], \"resolvers\": [ \"resolver_type_string\" ]\n" +
@@ -425,7 +425,7 @@ public class ResolutionActionIT extends AbstractIT {
             "  },\n" +
             "  \"scope\": {\n" +
             "    \"include\": {\n" +
-            "      \"attributes\": { \"attribute_d\": [ \"d_00\" ], \"attribute_type_double\": [ 3.141592653589793 ] },\n" +
+            "      \"attributes\": { \"attribute_d\": [ \"d_00\" ], \"attribute_type.number.double\": [ 3.141592653589793 ] },\n" +
             "      \"indices\": [ \"zentity_test_index_a\", \"zentity_test_index_b\", \"zentity_test_index_c\", \"zentity_test_index_d\" ],\n" +
             "      \"resolvers\": [ \"resolver_a\", \"resolver_b\", \"resolver_c\" ]\n" +
             "    }\n" +
@@ -436,7 +436,7 @@ public class ResolutionActionIT extends AbstractIT {
             "  \"terms\": [ \"d_00\" ],\n" +
             "  \"scope\": {\n" +
             "    \"include\": {\n" +
-            "      \"attributes\": { \"attribute_d\": [ \"d_00\" ], \"attribute_type_double\": [ 3.141592653589793 ] },\n" +
+            "      \"attributes\": { \"attribute_d\": [ \"d_00\" ], \"attribute_type.number.double\": [ 3.141592653589793 ] },\n" +
             "      \"indices\": [ \"zentity_test_index_a\", \"zentity_test_index_b\", \"zentity_test_index_c\", \"zentity_test_index_d\" ],\n" +
             "      \"resolvers\": [ \"resolver_a\", \"resolver_b\", \"resolver_c\" ]\n" +
             "    }\n" +
@@ -452,7 +452,7 @@ public class ResolutionActionIT extends AbstractIT {
             "      \"attributes\": { \"attribute_c\": [ \"c_00\", \"c_01\" ] }\n" +
             "    },\n" +
             "    \"include\": {\n" +
-            "      \"attributes\": { \"attribute_d\": [ \"d_00\" ], \"attribute_type_double\": [ 3.141592653589793 ] },\n" +
+            "      \"attributes\": { \"attribute_d\": [ \"d_00\" ], \"attribute_type.number.double\": [ 3.141592653589793 ] },\n" +
             "      \"indices\": [ \"zentity_test_index_a\", \"zentity_test_index_b\", \"zentity_test_index_c\", \"zentity_test_index_d\" ],\n" +
             "      \"resolvers\": [ \"resolver_a\", \"resolver_b\", \"resolver_c\" ]\n" +
             "    }\n" +
@@ -466,7 +466,7 @@ public class ResolutionActionIT extends AbstractIT {
             "      \"attributes\": { \"attribute_c\": [ \"c_00\", \"c_01\" ] }\n" +
             "    },\n" +
             "    \"include\": {\n" +
-            "      \"attributes\": { \"attribute_d\": [ \"d_00\" ], \"attribute_type_double\": [ 3.141592653589793 ] },\n" +
+            "      \"attributes\": { \"attribute_d\": [ \"d_00\" ], \"attribute_type.number.double\": [ 3.141592653589793 ] },\n" +
             "      \"indices\": [ \"zentity_test_index_a\", \"zentity_test_index_b\", \"zentity_test_index_c\", \"zentity_test_index_d\" ],\n" +
             "      \"resolvers\": [ \"resolver_a\", \"resolver_b\", \"resolver_c\" ]\n" +
             "    }\n" +
@@ -649,8 +649,8 @@ public class ResolutionActionIT extends AbstractIT {
         JsonNode json = Json.MAPPER.readTree(response.getEntity().getContent());
         assertEquals(json.get("hits").get("total").asInt(), 40);
         JsonPointer pathAttributes = JsonPointer.compile("/_attributes");
-        JsonPointer pathNull = JsonPointer.compile("/_attributes/attribute_type_string_null");
-        JsonPointer pathUnused = JsonPointer.compile("/_attributes/attribute_type_string_unused");
+        JsonPointer pathNull = JsonPointer.compile("/_attributes/attribute_type.string.null");
+        JsonPointer pathUnused = JsonPointer.compile("/_attributes/attribute_type.string.unused");
         for (JsonNode doc : json.get("hits").get("hits")) {
             assertFalse(doc.at(pathAttributes).isMissingNode());
             assertTrue(doc.at(pathNull).isMissingNode());
@@ -671,8 +671,8 @@ public class ResolutionActionIT extends AbstractIT {
         JsonNode json = Json.MAPPER.readTree(response.getEntity().getContent());
         assertEquals(json.get("hits").get("total").asInt(), 40);
         JsonPointer pathAttributes = JsonPointer.compile("/_attributes");
-        JsonPointer pathNull = JsonPointer.compile("/_attributes/attribute_type_string_null");
-        JsonPointer pathUnused = JsonPointer.compile("/_attributes/attribute_type_string_unused");
+        JsonPointer pathNull = JsonPointer.compile("/_attributes/attribute_type.string.null");
+        JsonPointer pathUnused = JsonPointer.compile("/_attributes/attribute_type.string.unused");
         for (JsonNode doc : json.get("hits").get("hits")) {
             assertFalse(doc.at(pathAttributes).isMissingNode());
             assertTrue(doc.at(pathNull).isMissingNode());
@@ -738,13 +738,13 @@ public class ResolutionActionIT extends AbstractIT {
             String expected = "";
             switch (doc.get("_id").asText()) {
                 case "a0":
-                    expected = "{\"resolvers\":{\"resolver_a\":{\"attributes\":[\"attribute_a\"]},\"resolver_type_date_a\":{\"attributes\":[\"attribute_a\",\"attribute_type_date\"]}},\"matches\":[{\"attribute\":\"attribute_a\",\"target_field\":\"field_a.clean\",\"target_value\":\"a_00\",\"input_value\":\"a_00\",\"input_matcher\":\"matcher_a\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_a\",\"target_field\":\"field_a.keyword\",\"target_value\":\"a_00\",\"input_value\":\"a_00\",\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type_date\",\"target_field\":\"type_date\",\"target_value\":\"1999-12-31T23:59:57.0000\",\"input_value\":\"1999-12-31T23:59:57.0000\",\"input_matcher\":\"matcher_c\",\"input_matcher_params\":{\"format\":\"yyyy-MM-dd'T'HH:mm:ss.0000\",\"window\":\"1d\"}}]}";
+                    expected = "{\"resolvers\":{\"resolver_a\":{\"attributes\":[\"attribute_a\"]},\"resolver_type_date_a\":{\"attributes\":[\"attribute_a\",\"attribute_type.date\"]}},\"matches\":[{\"attribute\":\"attribute_a\",\"target_field\":\"field_a.clean\",\"target_value\":\"a_00\",\"input_value\":\"a_00\",\"input_matcher\":\"matcher_a\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_a\",\"target_field\":\"field_a.keyword\",\"target_value\":\"a_00\",\"input_value\":\"a_00\",\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type.date\",\"target_field\":\"type_date\",\"target_value\":\"1999-12-31T23:59:57.0000\",\"input_value\":\"1999-12-31T23:59:57.0000\",\"input_matcher\":\"matcher_c\",\"input_matcher_params\":{\"format\":\"yyyy-MM-dd'T'HH:mm:ss.0000\",\"window\":\"1d\"}}]}";
                     break;
                 case "a1":
-                    expected = "{\"resolvers\":{\"resolver_c\":{\"attributes\":[\"attribute_d\"]},\"resolver_type_date_c\":{\"attributes\":[\"attribute_d\",\"attribute_type_date\"]}},\"matches\":[{\"attribute\":\"attribute_d\",\"target_field\":\"field_d.clean\",\"target_value\":\"d_00\",\"input_value\":\"d_00\",\"input_matcher\":\"matcher_a\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_d\",\"target_field\":\"field_d.keyword\",\"target_value\":\"d_00\",\"input_value\":\"d_00\",\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type_date\",\"target_field\":\"type_date\",\"target_value\":\"1999-12-31T23:59:59.0000\",\"input_value\":\"1999-12-31T23:59:57.0000\",\"input_matcher\":\"matcher_c\",\"input_matcher_params\":{\"format\":\"yyyy-MM-dd'T'HH:mm:ss.0000\",\"window\":\"1d\"}}]}";
+                    expected = "{\"resolvers\":{\"resolver_c\":{\"attributes\":[\"attribute_d\"]},\"resolver_type_date_c\":{\"attributes\":[\"attribute_d\",\"attribute_type.date\"]}},\"matches\":[{\"attribute\":\"attribute_d\",\"target_field\":\"field_d.clean\",\"target_value\":\"d_00\",\"input_value\":\"d_00\",\"input_matcher\":\"matcher_a\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_d\",\"target_field\":\"field_d.keyword\",\"target_value\":\"d_00\",\"input_value\":\"d_00\",\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type.date\",\"target_field\":\"type_date\",\"target_value\":\"1999-12-31T23:59:59.0000\",\"input_value\":\"1999-12-31T23:59:57.0000\",\"input_matcher\":\"matcher_c\",\"input_matcher_params\":{\"format\":\"yyyy-MM-dd'T'HH:mm:ss.0000\",\"window\":\"1d\"}}]}";
                     break;
                 case "a2":
-                    expected = "{\"resolvers\":{\"resolver_c\":{\"attributes\":[\"attribute_d\"]},\"resolver_object\":{\"attributes\":[\"attribute_object\"]},\"resolver_type_boolean\":{\"attributes\":[\"attribute_type_boolean\"]},\"resolver_type_date_c\":{\"attributes\":[\"attribute_d\",\"attribute_type_date\"]},\"resolver_type_double\":{\"attributes\":[\"attribute_type_double\"]},\"resolver_type_float\":{\"attributes\":[\"attribute_type_float\"]},\"resolver_type_integer\":{\"attributes\":[\"attribute_type_integer\"]},\"resolver_type_long\":{\"attributes\":[\"attribute_type_long\"]},\"resolver_type_string\":{\"attributes\":[\"attribute_type_string\"]}},\"matches\":[{\"attribute\":\"attribute_d\",\"target_field\":\"field_d.clean\",\"target_value\":\"d_00\",\"input_value\":\"d_00\",\"input_matcher\":\"matcher_a\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_d\",\"target_field\":\"field_d.keyword\",\"target_value\":\"d_00\",\"input_value\":\"d_00\",\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_object\",\"target_field\":\"object.a.b.c.keyword\",\"target_value\":\"a\",\"input_value\":\"a\",\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type_boolean\",\"target_field\":\"type_boolean\",\"target_value\":true,\"input_value\":true,\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type_date\",\"target_field\":\"type_date\",\"target_value\":\"2000-01-01T00:00:00.0000\",\"input_value\":\"1999-12-31T23:59:57.0000\",\"input_matcher\":\"matcher_c\",\"input_matcher_params\":{\"format\":\"yyyy-MM-dd'T'HH:mm:ss.0000\",\"window\":\"1d\"}},{\"attribute\":\"attribute_type_double\",\"target_field\":\"type_double\",\"target_value\":3.141592653589793,\"input_value\":3.141592653589793,\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type_float\",\"target_field\":\"type_float\",\"target_value\":1.0,\"input_value\":1.0,\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type_integer\",\"target_field\":\"type_integer\",\"target_value\":1,\"input_value\":1,\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type_long\",\"target_field\":\"type_long\",\"target_value\":922337203685477,\"input_value\":922337203685477,\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type_string\",\"target_field\":\"type_string\",\"target_value\":\"a\",\"input_value\":\"a\",\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}}]}";
+                    expected = "{\"resolvers\":{\"resolver_c\":{\"attributes\":[\"attribute_d\"]},\"resolver_object\":{\"attributes\":[\"attribute_object\"]},\"resolver_type_boolean\":{\"attributes\":[\"attribute_type.boolean\"]},\"resolver_type_date_c\":{\"attributes\":[\"attribute_d\",\"attribute_type.date\"]},\"resolver_type_double\":{\"attributes\":[\"attribute_type.number.double\"]},\"resolver_type_float\":{\"attributes\":[\"attribute_type.number.float\"]},\"resolver_type_integer\":{\"attributes\":[\"attribute_type.number.integer\"]},\"resolver_type_long\":{\"attributes\":[\"attribute_type.number.long\"]},\"resolver_type_string\":{\"attributes\":[\"attribute_type.string.normal\"]}},\"matches\":[{\"attribute\":\"attribute_d\",\"target_field\":\"field_d.clean\",\"target_value\":\"d_00\",\"input_value\":\"d_00\",\"input_matcher\":\"matcher_a\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_d\",\"target_field\":\"field_d.keyword\",\"target_value\":\"d_00\",\"input_value\":\"d_00\",\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_object\",\"target_field\":\"object.a.b.c.keyword\",\"target_value\":\"a\",\"input_value\":\"a\",\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type.boolean\",\"target_field\":\"type_boolean\",\"target_value\":true,\"input_value\":true,\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type.date\",\"target_field\":\"type_date\",\"target_value\":\"2000-01-01T00:00:00.0000\",\"input_value\":\"1999-12-31T23:59:57.0000\",\"input_matcher\":\"matcher_c\",\"input_matcher_params\":{\"format\":\"yyyy-MM-dd'T'HH:mm:ss.0000\",\"window\":\"1d\"}},{\"attribute\":\"attribute_type.number.double\",\"target_field\":\"type_double\",\"target_value\":3.141592653589793,\"input_value\":3.141592653589793,\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type.number.float\",\"target_field\":\"type_float\",\"target_value\":1.0,\"input_value\":1.0,\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type.number.integer\",\"target_field\":\"type_integer\",\"target_value\":1,\"input_value\":1,\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type.number.long\",\"target_field\":\"type_long\",\"target_value\":922337203685477,\"input_value\":922337203685477,\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type.string.normal\",\"target_field\":\"type_string\",\"target_value\":\"a\",\"input_value\":\"a\",\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}}]}";
                     break;
             }
             assertEquals(expected, Json.MAPPER.writeValueAsString(doc.get("_explanation")));
@@ -773,13 +773,13 @@ public class ResolutionActionIT extends AbstractIT {
             String expected = "";
             switch (doc.get("_id").asText()) {
                 case "a0":
-                    expected = "{\"resolvers\":{\"resolver_a\":{\"attributes\":[\"attribute_a\"]},\"resolver_type_date_a\":{\"attributes\":[\"attribute_a\",\"attribute_type_date\"]}},\"matches\":[{\"attribute\":\"attribute_a\",\"target_field\":\"field_a.clean\",\"target_value\":\"a_00\",\"input_value\":\"a_00\",\"input_matcher\":\"matcher_a\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_a\",\"target_field\":\"field_a.keyword\",\"target_value\":\"a_00\",\"input_value\":\"a_00\",\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type_date\",\"target_field\":\"type_date\",\"target_value\":\"1999-12-31T23:59:57.0000\",\"input_value\":\"1999-12-31T23:59:57.0000\",\"input_matcher\":\"matcher_c\",\"input_matcher_params\":{\"format\":\"yyyy-MM-dd'T'HH:mm:ss.0000\",\"window\":\"1d\"}}]}";
+                    expected = "{\"resolvers\":{\"resolver_a\":{\"attributes\":[\"attribute_a\"]},\"resolver_type_date_a\":{\"attributes\":[\"attribute_a\",\"attribute_type.date\"]}},\"matches\":[{\"attribute\":\"attribute_a\",\"target_field\":\"field_a.clean\",\"target_value\":\"a_00\",\"input_value\":\"a_00\",\"input_matcher\":\"matcher_a\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_a\",\"target_field\":\"field_a.keyword\",\"target_value\":\"a_00\",\"input_value\":\"a_00\",\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type.date\",\"target_field\":\"type_date\",\"target_value\":\"1999-12-31T23:59:57.0000\",\"input_value\":\"1999-12-31T23:59:57.0000\",\"input_matcher\":\"matcher_c\",\"input_matcher_params\":{\"format\":\"yyyy-MM-dd'T'HH:mm:ss.0000\",\"window\":\"1d\"}}]}";
                     break;
                 case "a1":
-                    expected = "{\"resolvers\":{\"resolver_c\":{\"attributes\":[\"attribute_d\"]},\"resolver_type_date_c\":{\"attributes\":[\"attribute_d\",\"attribute_type_date\"]}},\"matches\":[{\"attribute\":\"attribute_d\",\"target_field\":\"field_d.clean\",\"target_value\":\"d_00\",\"input_value\":\"d_00\",\"input_matcher\":\"matcher_a\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_d\",\"target_field\":\"field_d.keyword\",\"target_value\":\"d_00\",\"input_value\":\"d_00\",\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type_date\",\"target_field\":\"type_date\",\"target_value\":\"1999-12-31T23:59:59.0000\",\"input_value\":\"1999-12-31T23:59:57.0000\",\"input_matcher\":\"matcher_c\",\"input_matcher_params\":{\"format\":\"yyyy-MM-dd'T'HH:mm:ss.0000\",\"window\":\"1d\"}}]}";
+                    expected = "{\"resolvers\":{\"resolver_c\":{\"attributes\":[\"attribute_d\"]},\"resolver_type_date_c\":{\"attributes\":[\"attribute_d\",\"attribute_type.date\"]}},\"matches\":[{\"attribute\":\"attribute_d\",\"target_field\":\"field_d.clean\",\"target_value\":\"d_00\",\"input_value\":\"d_00\",\"input_matcher\":\"matcher_a\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_d\",\"target_field\":\"field_d.keyword\",\"target_value\":\"d_00\",\"input_value\":\"d_00\",\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type.date\",\"target_field\":\"type_date\",\"target_value\":\"1999-12-31T23:59:59.0000\",\"input_value\":\"1999-12-31T23:59:57.0000\",\"input_matcher\":\"matcher_c\",\"input_matcher_params\":{\"format\":\"yyyy-MM-dd'T'HH:mm:ss.0000\",\"window\":\"1d\"}}]}";
                     break;
                 case "a2":
-                    expected = "{\"resolvers\":{\"resolver_c\":{\"attributes\":[\"attribute_d\"]},\"resolver_object\":{\"attributes\":[\"attribute_object\"]},\"resolver_type_boolean\":{\"attributes\":[\"attribute_type_boolean\"]},\"resolver_type_date_c\":{\"attributes\":[\"attribute_d\",\"attribute_type_date\"]},\"resolver_type_double\":{\"attributes\":[\"attribute_type_double\"]},\"resolver_type_float\":{\"attributes\":[\"attribute_type_float\"]},\"resolver_type_integer\":{\"attributes\":[\"attribute_type_integer\"]},\"resolver_type_long\":{\"attributes\":[\"attribute_type_long\"]},\"resolver_type_string\":{\"attributes\":[\"attribute_type_string\"]}},\"matches\":[{\"attribute\":\"attribute_d\",\"target_field\":\"field_d.clean\",\"target_value\":\"d_00\",\"input_value\":\"d_00\",\"input_matcher\":\"matcher_a\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_d\",\"target_field\":\"field_d.keyword\",\"target_value\":\"d_00\",\"input_value\":\"d_00\",\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_object\",\"target_field\":\"object.a.b.c.keyword\",\"target_value\":\"a\",\"input_value\":\"a\",\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type_boolean\",\"target_field\":\"type_boolean\",\"target_value\":true,\"input_value\":true,\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type_date\",\"target_field\":\"type_date\",\"target_value\":\"2000-01-01T00:00:00.0000\",\"input_value\":\"1999-12-31T23:59:57.0000\",\"input_matcher\":\"matcher_c\",\"input_matcher_params\":{\"format\":\"yyyy-MM-dd'T'HH:mm:ss.0000\",\"window\":\"1d\"}},{\"attribute\":\"attribute_type_double\",\"target_field\":\"type_double\",\"target_value\":3.141592653589793,\"input_value\":3.141592653589793,\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type_float\",\"target_field\":\"type_float\",\"target_value\":1.0,\"input_value\":1.0,\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type_integer\",\"target_field\":\"type_integer\",\"target_value\":1,\"input_value\":1,\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type_long\",\"target_field\":\"type_long\",\"target_value\":922337203685477,\"input_value\":922337203685477,\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type_string\",\"target_field\":\"type_string\",\"target_value\":\"a\",\"input_value\":\"a\",\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}}]}";
+                    expected = "{\"resolvers\":{\"resolver_c\":{\"attributes\":[\"attribute_d\"]},\"resolver_object\":{\"attributes\":[\"attribute_object\"]},\"resolver_type_boolean\":{\"attributes\":[\"attribute_type.boolean\"]},\"resolver_type_date_c\":{\"attributes\":[\"attribute_d\",\"attribute_type.date\"]},\"resolver_type_double\":{\"attributes\":[\"attribute_type.number.double\"]},\"resolver_type_float\":{\"attributes\":[\"attribute_type.number.float\"]},\"resolver_type_integer\":{\"attributes\":[\"attribute_type.number.integer\"]},\"resolver_type_long\":{\"attributes\":[\"attribute_type.number.long\"]},\"resolver_type_string\":{\"attributes\":[\"attribute_type.string.normal\"]}},\"matches\":[{\"attribute\":\"attribute_d\",\"target_field\":\"field_d.clean\",\"target_value\":\"d_00\",\"input_value\":\"d_00\",\"input_matcher\":\"matcher_a\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_d\",\"target_field\":\"field_d.keyword\",\"target_value\":\"d_00\",\"input_value\":\"d_00\",\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_object\",\"target_field\":\"object.a.b.c.keyword\",\"target_value\":\"a\",\"input_value\":\"a\",\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type.boolean\",\"target_field\":\"type_boolean\",\"target_value\":true,\"input_value\":true,\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type.date\",\"target_field\":\"type_date\",\"target_value\":\"2000-01-01T00:00:00.0000\",\"input_value\":\"1999-12-31T23:59:57.0000\",\"input_matcher\":\"matcher_c\",\"input_matcher_params\":{\"format\":\"yyyy-MM-dd'T'HH:mm:ss.0000\",\"window\":\"1d\"}},{\"attribute\":\"attribute_type.number.double\",\"target_field\":\"type_double\",\"target_value\":3.141592653589793,\"input_value\":3.141592653589793,\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type.number.float\",\"target_field\":\"type_float\",\"target_value\":1.0,\"input_value\":1.0,\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type.number.integer\",\"target_field\":\"type_integer\",\"target_value\":1,\"input_value\":1,\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type.number.long\",\"target_field\":\"type_long\",\"target_value\":922337203685477,\"input_value\":922337203685477,\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}},{\"attribute\":\"attribute_type.string.normal\",\"target_field\":\"type_string\",\"target_value\":\"a\",\"input_value\":\"a\",\"input_matcher\":\"matcher_b\",\"input_matcher_params\":{}}]}";
                     break;
             }
             assertEquals(expected, Json.MAPPER.writeValueAsString(doc.get("_explanation")));

--- a/src/test/resources/TestEntityModelA.json
+++ b/src/test/resources/TestEntityModelA.json
@@ -13,32 +13,32 @@
     "attribute_d": {
       "score": 0.5
     },
-    "attribute_type_boolean": {
+    "attribute_type.boolean": {
       "type": "boolean",
       "score": 0.5
     },
-    "attribute_type_date": {
+    "attribute_type.date": {
       "type": "date",
       "score": 0.9
     },
-    "attribute_type_double": {
+    "attribute_type.number.double": {
       "type": "number",
       "score": 0.75
     },
-    "attribute_type_float": {
+    "attribute_type.number.float": {
       "type": "number"
     },
-    "attribute_type_integer": {
+    "attribute_type.number.integer": {
       "type": "number",
       "score": 0.65
     },
-    "attribute_type_long": {
+    "attribute_type.number.long": {
       "type": "number"
     },
-    "attribute_type_string": {
+    "attribute_type.string.normal": {
       "type": "string"
     },
-    "attribute_type_string_null": {
+    "attribute_type.string.null": {
       "type": "string"
     },
     "attribute_object": {
@@ -67,56 +67,56 @@
     },
     "resolver_type_boolean": {
       "attributes": [
-        "attribute_type_boolean"
+        "attribute_type.boolean"
       ]
     },
     "resolver_type_date_a": {
       "attributes": [
         "attribute_a",
-        "attribute_type_date"
+        "attribute_type.date"
       ]
     },
     "resolver_type_date_b": {
       "attributes": [
         "attribute_b",
         "attribute_c",
-        "attribute_type_date"
+        "attribute_type.date"
       ]
     },
     "resolver_type_date_c": {
       "attributes": [
         "attribute_d",
-        "attribute_type_date"
+        "attribute_type.date"
       ]
     },
     "resolver_type_double": {
       "attributes": [
-        "attribute_type_double"
+        "attribute_type.number.double"
       ]
     },
     "resolver_type_float": {
       "attributes": [
-        "attribute_type_float"
+        "attribute_type.number.float"
       ]
     },
     "resolver_type_integer": {
       "attributes": [
-        "attribute_type_integer"
+        "attribute_type.number.integer"
       ]
     },
     "resolver_type_long": {
       "attributes": [
-        "attribute_type_long"
+        "attribute_type.number.long"
       ]
     },
     "resolver_type_string": {
       "attributes": [
-        "attribute_type_string"
+        "attribute_type.string.normal"
       ]
     },
     "resolver_type_string_null": {
       "attributes": [
-        "attribute_type_string_null"
+        "attribute_type.string.null"
       ]
     },
     "resolver_object": {
@@ -204,35 +204,35 @@
           "quality": 0.95
         },
         "type_boolean": {
-          "attribute": "attribute_type_boolean",
+          "attribute": "attribute_type.boolean",
           "matcher": "matcher_b"
         },
         "type_date": {
-          "attribute": "attribute_type_date",
+          "attribute": "attribute_type.date",
           "matcher": "matcher_c"
         },
         "type_double": {
-          "attribute": "attribute_type_double",
+          "attribute": "attribute_type.number.double",
           "matcher": "matcher_b"
         },
         "type_float": {
-          "attribute": "attribute_type_float",
+          "attribute": "attribute_type.number.float",
           "matcher": "matcher_b"
         },
         "type_integer": {
-          "attribute": "attribute_type_integer",
+          "attribute": "attribute_type.number.integer",
           "matcher": "matcher_b"
         },
         "type_long": {
-          "attribute": "attribute_type_long",
+          "attribute": "attribute_type.number.long",
           "matcher": "matcher_b"
         },
         "type_string": {
-          "attribute": "attribute_type_string",
+          "attribute": "attribute_type.string.normal",
           "matcher": "matcher_b"
         },
         "type_string_null": {
-          "attribute": "attribute_type_string_null",
+          "attribute": "attribute_type.string.null",
           "matcher": "matcher_b"
         },
         "object.a.b.c.keyword": {
@@ -283,35 +283,35 @@
           "matcher": "matcher_b"
         },
         "type_boolean": {
-          "attribute": "attribute_type_boolean",
+          "attribute": "attribute_type.boolean",
           "matcher": "matcher_b"
         },
         "type_date": {
-          "attribute": "attribute_type_date",
+          "attribute": "attribute_type.date",
           "matcher": "matcher_c"
         },
         "type_double": {
-          "attribute": "attribute_type_double",
+          "attribute": "attribute_type.number.double",
           "matcher": "matcher_b"
         },
         "type_float": {
-          "attribute": "attribute_type_float",
+          "attribute": "attribute_type.number.float",
           "matcher": "matcher_b"
         },
         "type_integer": {
-          "attribute": "attribute_type_integer",
+          "attribute": "attribute_type.number.integer",
           "matcher": "matcher_b"
         },
         "type_long": {
-          "attribute": "attribute_type_long",
+          "attribute": "attribute_type.number.long",
           "matcher": "matcher_b"
         },
         "type_string": {
-          "attribute": "attribute_type_string",
+          "attribute": "attribute_type.string.normal",
           "matcher": "matcher_b"
         },
         "type_string_null": {
-          "attribute": "attribute_type_string_null",
+          "attribute": "attribute_type.string.null",
           "matcher": "matcher_b"
         },
         "object.a.b.c.keyword": {
@@ -359,35 +359,35 @@
           "matcher": "matcher_b"
         },
         "type_boolean": {
-          "attribute": "attribute_type_boolean",
+          "attribute": "attribute_type.boolean",
           "matcher": "matcher_b"
         },
         "type_date": {
-          "attribute": "attribute_type_date",
+          "attribute": "attribute_type.date",
           "matcher": "matcher_c"
         },
         "type_double": {
-          "attribute": "attribute_type_double",
+          "attribute": "attribute_type.number.double",
           "matcher": "matcher_b"
         },
         "type_float": {
-          "attribute": "attribute_type_float",
+          "attribute": "attribute_type.number.float",
           "matcher": "matcher_b"
         },
         "type_integer": {
-          "attribute": "attribute_type_integer",
+          "attribute": "attribute_type.number.integer",
           "matcher": "matcher_b"
         },
         "type_long": {
-          "attribute": "attribute_type_long",
+          "attribute": "attribute_type.number.long",
           "matcher": "matcher_b"
         },
         "type_string": {
-          "attribute": "attribute_type_string",
+          "attribute": "attribute_type.string.normal",
           "matcher": "matcher_b"
         },
         "type_string_null": {
-          "attribute": "attribute_type_string_null",
+          "attribute": "attribute_type.string.null",
           "matcher": "matcher_b"
         },
         "object.a.b.c.keyword": {
@@ -439,36 +439,36 @@
           "quality": 0.95
         },
         "type_boolean": {
-          "attribute": "attribute_type_boolean",
+          "attribute": "attribute_type.boolean",
           "matcher": "matcher_b",
           "quality": 0.0
         },
         "type_date": {
-          "attribute": "attribute_type_date",
+          "attribute": "attribute_type.date",
           "matcher": "matcher_c"
         },
         "type_double": {
-          "attribute": "attribute_type_double",
+          "attribute": "attribute_type.number.double",
           "matcher": "matcher_b"
         },
         "type_float": {
-          "attribute": "attribute_type_float",
+          "attribute": "attribute_type.number.float",
           "matcher": "matcher_b"
         },
         "type_integer": {
-          "attribute": "attribute_type_integer",
+          "attribute": "attribute_type.number.integer",
           "matcher": "matcher_b"
         },
         "type_long": {
-          "attribute": "attribute_type_long",
+          "attribute": "attribute_type.number.long",
           "matcher": "matcher_b"
         },
         "type_string": {
-          "attribute": "attribute_type_string",
+          "attribute": "attribute_type.string.normal",
           "matcher": "matcher_b"
         },
         "type_string_null": {
-          "attribute": "attribute_type_string_null",
+          "attribute": "attribute_type.string.null",
           "matcher": "matcher_b"
         },
         "object.a.b.c.keyword": {
@@ -483,8 +483,7 @@
           "attribute": "attribute_unused"
         },
         "unused_matcher_null": {
-          "attribute": "attribute_unused",
-          "matcher": null
+          "attribute": "attribute_unused"
         }
       }
     }


### PR DESCRIPTION
The Job class now structures the `"_attributes"` object of the response by splitting the attribute names by periods and nesting them. For example, an attribute named `"location.address.street"` becomes structured as `{ "location": { "address": { "street": [ VALUE, ... ] }}}` in the `"_attributes"` object. The Model class validates that the names of attributes do not override one another. Example: A model with attributes `"name.first"` and `"name.last"` is valid, but a model with attributes `"name"` and `"name.first"` is invalid because `"name.first"` will override `"name"` in the `"_attributes"` section of the resolution response.

Closes #77 