### PR TITLE
feature-bulk-model-management

### DIFF
--- a/src/main/java/io/zentity/common/AsyncCollectionRunner.java
+++ b/src/main/java/io/zentity/common/AsyncCollectionRunner.java
@@ -1,7 +1,6 @@
 package io.zentity.common;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.common.collect.Tuple;
 
 import java.util.Collection;
 import java.util.Deque;

--- a/src/main/java/io/zentity/common/Patterns.java
+++ b/src/main/java/io/zentity/common/Patterns.java
@@ -2,13 +2,16 @@ package io.zentity.common;
 
 import java.util.regex.Pattern;
 
+/**
+ * Regular expression patterns to compile once when the zentity plugin loads.
+ */
 public class Patterns {
 
     public static final Pattern COLON = Pattern.compile(":");
     public static final Pattern EMPTY_STRING = Pattern.compile("^\\s*$");
+    public static final Pattern NEWLINE = Pattern.compile("\\r?\\n");
     public static final Pattern NUMBER_STRING = Pattern.compile("^-?\\d*\\.{0,1}\\d+$");
     public static final Pattern PERIOD = Pattern.compile("\\.");
     public static final Pattern VARIABLE = Pattern.compile("\\{\\{\\s*([^\\s{}]+)\\s*}}");
     public static final Pattern VARIABLE_PARAMS = Pattern.compile("^params\\.(.+)");
-
 }

--- a/src/main/java/io/zentity/model/Model.java
+++ b/src/main/java/io/zentity/model/Model.java
@@ -71,6 +71,8 @@ public class Model {
      */
     public static void validateStrictName(String name) throws ValidationException {
         BiFunction<String, String, String> msg = (invalidName, description) -> "Invalid name [" + invalidName + "], " + description;
+        if (name == null)
+            throw new ValidationException(msg.apply("", "must not be empty"));
         if (Patterns.EMPTY_STRING.matcher(name).matches())
             throw new ValidationException(msg.apply(name, "must not be empty"));
         if (!Strings.validFileName(name))

--- a/src/main/java/org/elasticsearch/plugin/zentity/BulkAction.java
+++ b/src/main/java/org/elasticsearch/plugin/zentity/BulkAction.java
@@ -1,0 +1,73 @@
+package org.elasticsearch.plugin.zentity;
+
+import io.zentity.common.Json;
+import io.zentity.common.Patterns;
+import io.zentity.common.StreamUtil;
+import joptsimple.internal.Strings;
+import org.elasticsearch.common.collect.Tuple;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class BulkAction {
+
+    public static final int MAX_CONCURRENT_OPERATIONS_PER_REQUEST = 100;
+
+    /**
+     * Split an NDJSON-formatted string into pairs of params and payloads.
+     *
+     * @param body NDJSON-formatted string.
+     * @return
+     */
+    static List<Tuple<String, String>> splitBulkEntries(String body) {
+        String[] lines = Patterns.NEWLINE.split(body);
+        if (lines.length % 2 != 0)
+            throw new BadRequestException("Bulk request must have repeating pairs of params and payloads on separate lines.");
+        return Arrays.stream(lines)
+            .flatMap(StreamUtil.tupleFlatmapper())
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Serialize the response of a bulk request.
+     *
+     * @param result The result of a bulk request.
+     * @return
+     */
+    static String bulkResultToJson(BulkResult result) {
+        return "{" +
+            Json.quoteString("took") + ":" + result.took +
+            "," + Json.quoteString("errors") + ":" + result.errors +
+            "," + Json.quoteString("items") + ":" + "[" + Strings.join(result.items, ",") + "]" +
+            "}";
+    }
+
+    /**
+     * Small wrapper around a single response for a bulk request.
+     */
+    static final class SingleResult {
+        final String response;
+        final boolean failed;
+
+        SingleResult(String response, boolean failed) {
+            this.response = response;
+            this.failed = failed;
+        }
+    }
+
+    /**
+     * A wrapper for a collection of single responses for a bulk request.
+     */
+    static final class BulkResult {
+        final List<String> items;
+        final boolean errors;
+        final long took;
+
+        BulkResult(List<String> items, boolean errors, long took) {
+            this.items = items;
+            this.errors = errors;
+            this.took = took;
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/plugin/zentity/ModelsAction.java
+++ b/src/main/java/org/elasticsearch/plugin/zentity/ModelsAction.java
@@ -50,6 +50,8 @@ import static org.elasticsearch.rest.RestRequest.Method.PUT;
 public class ModelsAction extends BaseRestHandler {
 
     private static final Logger logger = LogManager.getLogger(ModelsAction.class);
+
+    // Bulk model management operations must run in series, not in parallel
     private static final int MAX_CONCURRENT_OPERATIONS_PER_REQUEST = 1;
 
     public static final String INDEX_NAME = ".zentity-models";
@@ -516,7 +518,6 @@ public class ModelsAction extends BaseRestHandler {
                 if (entityType == null || entityType.equals("")) {
 
                     // GET _zentity/models
-                    // An error occurred when retrieving the entity models.
                     getEntityModels(client, ActionListener.wrap(
 
                             // Success
@@ -534,7 +535,6 @@ public class ModelsAction extends BaseRestHandler {
                 } else {
 
                     // GET _zentity/models/{entity_type}
-                    // An error occurred when retrieving the entity models.
                     getEntityModel(entityType, client, ActionListener.wrap(
 
                             // Success

--- a/src/main/java/org/elasticsearch/plugin/zentity/ResolutionAction.java
+++ b/src/main/java/org/elasticsearch/plugin/zentity/ResolutionAction.java
@@ -287,7 +287,7 @@ public class ResolutionAction extends BaseRestHandler {
         return channel -> {
             Consumer<Exception> errorHandler = (e) -> ZentityPlugin.sendResponseError(channel, logger, e);
             try {
-                boolean isBulkRequest = restRequest.path().endsWith("_bulk");
+                boolean isBulkRequest = restRequest.path().endsWith("/_bulk");
                 if (isBulkRequest) {
 
                     // Run bulk jobs

--- a/src/main/java/org/elasticsearch/plugin/zentity/ZentityPlugin.java
+++ b/src/main/java/org/elasticsearch/plugin/zentity/ZentityPlugin.java
@@ -151,4 +151,26 @@ public class ZentityPlugin extends Plugin implements ActionPlugin {
     protected static void sendResponse(RestChannel channel, XContentBuilder content) {
         sendResponse(channel, RestStatus.OK, content);
     }
+
+    /**
+     * Return a response through a RestChannel.
+     * This method is used by the action classes in org.elasticsearch.plugin.zentity.
+     *
+     * @param channel The REST channel to return the response through.
+     * @param json    The JSON string to process and return.
+     */
+    protected static void sendResponse(RestChannel channel, RestStatus statusCode, String json) {
+        channel.sendResponse(new BytesRestResponse(statusCode, "application/json", json));
+    }
+
+    /**
+     * Return a response through a RestChannel.
+     * This method is used by the action classes in org.elasticsearch.plugin.zentity.
+     *
+     * @param channel The REST channel to return the response through.
+     * @param json    The JSON string to process and return.
+     */
+    protected static void sendResponse(RestChannel channel, String json) {
+        sendResponse(channel, RestStatus.OK, json);
+    }
 }

--- a/src/test/java/org/elasticsearch/plugin/zentity/ResolutionActionIT.java
+++ b/src/test/java/org/elasticsearch/plugin/zentity/ResolutionActionIT.java
@@ -1838,7 +1838,7 @@ public class ResolutionActionIT extends AbstractIT {
         }
     }
 
-    // BULK
+    ////  Bulk actions  ////////////////////////////////////////////////////////////////////////////////////////////////
 
     @Test
     public void testBulkResolutionWithMalformed() throws Exception {
@@ -1876,7 +1876,7 @@ public class ResolutionActionIT extends AbstractIT {
         assertTrue(json.get("items").isArray());
 
         // check the values
-        assertTrue(json.get("took").asLong() > 0);
+        assertTrue(json.get("took").asLong() >= 0);
         assertTrue(json.get("errors").booleanValue());
 
         ArrayNode items = (ArrayNode) json.get("items");


### PR DESCRIPTION
This PR introduces the Bulk Models API: `POST _zentity/models/_bulk`

The API performs a serial execution of multiple model management operations (`"create"`, `"update"`, `"delete"`).

Example:

```javascript
POST _zentity/models/_bulk
{"create":{"entity_type":"foo"}}
{"attributes":{},"resolvers":{},"matchers":{},"indices":{}}
{"update":{"entity_type":"foo"}}
{"attributes":{"foo":{}},"resolvers":{},"matchers":{},"indices":{}}
{"delete":{"entity_type":"foo"}}
{}
```

The API optimizes efficiency by only ensuring the existence of the `.zentity-models` index once at the beginning of the bulk request, and only refreshing the index once at the end of the bulk request.

The API syntax is almost identical to the [Elasticsearch Bulk API](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html), with the exception that `"delete"` operations must be followed by an empty object (`{}`) instead of skipping the object altogether.

Closes #57