### PR TITLE
feature-bulk-resolution-enhancements

### DIFF
--- a/src/main/java/io/zentity/common/Json.java
+++ b/src/main/java/io/zentity/common/Json.java
@@ -38,6 +38,8 @@ public class Json {
     }
 
     private static String jsonStringEscape(String value) {
+        if (value == null)
+            return "null"; // Prevents NullPointerException on STRING_ENCODER.quoteAsString()
         return new String(STRING_ENCODER.quoteAsString(value));
     }
 

--- a/src/main/java/org/elasticsearch/plugin/zentity/ModelsAction.java
+++ b/src/main/java/org/elasticsearch/plugin/zentity/ModelsAction.java
@@ -830,7 +830,7 @@ public class ModelsAction extends BaseRestHandler {
                         // Refresh the index so that the changes are immediately visible.
                         RefreshRequest request = new RefreshRequest(INDEX_NAME);
                         client.admin().indices().refresh(request, ActionListener.wrap(
-                                (refreshResponse) -> {logger.debug("refreshed"); listener.onResponse(singleResults);},
+                                (refreshResponse) -> listener.onResponse(singleResults),
                                 listener::onFailure
                         ));
                     }


### PR DESCRIPTION
@austince While working on examples for the docs, I found an optimization issue that I decided was worth fixing now. My changes are listed below -- the first item is what prompted me to address the change now:

- `POST _zentity/resolution/{entity_type}/_bulk` now retrieves the entity model once before all jobs, instead of once before each job. If the "entity_type" is not given in the URL, then each job will fetch its own entity model, unless the job has the model embedded in its payload.
- Ensure that an "entity_type" in a single bulk action overrides the "entity_type" in the URL.
- Ensure that an embedded "model" is accepted when "entity_type" is undefined.
- Fail the entire bulk request if the "entity_type" in the URL is not found, but allow single bulk actions to fail without failing the whole request if the action's own "entity_type" is not found.
- Fixed a potential NullPointerException in JSON serialization.
- Removed a needless log message.