### PR TITLE
Update log4j core to 2.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <jackson.core.version>2.10.5</jackson.core.version>
         <jackson.databind.version>2.10.5.1</jackson.databind.version>
         <jdk.version>1.11</jdk.version>
-        <log4j.version>2.11.1</log4j.version>
+        <log4j.version>2.17.1</log4j.version>
         <commons-io.version>2.8.0</commons-io.version>
         <testcontainers.version>1.16.0</testcontainers.version>
 

--- a/src/main/java/io/zentity/resolution/Job.java
+++ b/src/main/java/io/zentity/resolution/Job.java
@@ -48,8 +48,6 @@ import static io.zentity.common.Patterns.COLON;
 
 public class Job {
 
-    private static final Logger logger = LogManager.getLogger(Job.class);
-
     // Constants
     public static final boolean DEFAULT_INCLUDE_ATTRIBUTES = true;
     public static final boolean DEFAULT_INCLUDE_ERROR_TRACE = true;

--- a/src/main/java/io/zentity/resolution/Query.java
+++ b/src/main/java/io/zentity/resolution/Query.java
@@ -28,8 +28,6 @@ import io.zentity.resolution.input.Input;
 import io.zentity.resolution.input.Term;
 import io.zentity.resolution.input.value.StringValue;
 import io.zentity.resolution.input.value.Value;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.search.SearchAction;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.common.settings.Settings;
@@ -44,9 +42,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 
 public class Query {
-
-    private static final Logger logger = LogManager.getLogger(Query.class);
-
     private final String indexName;
     private final int number;
     private final String query;


### PR DESCRIPTION
Fixes some important security vulnerabilities listed here:
https://logging.apache.org/log4j/2.x/security.html#CVE-2021-45105

@davemoore- do you have any time to test this out? 

Closes https://github.com/zentity-io/zentity/pull/97
 