### PR TITLE
fix: Escape quotes and backslashes when performing substitution

### DIFF
--- a/src/main/java/io/zentity/common/Json.java
+++ b/src/main/java/io/zentity/common/Json.java
@@ -37,7 +37,7 @@ public class Json {
         return jsonStringFormat(value);
     }
 
-    private static String jsonStringEscape(String value) {
+    public static String jsonStringEscape(String value) {
         if (value == null)
             return "null"; // Prevents NullPointerException on STRING_ENCODER.quoteAsString()
         return new String(STRING_ENCODER.quoteAsString(value));

--- a/src/main/java/io/zentity/resolution/Query.java
+++ b/src/main/java/io/zentity/resolution/Query.java
@@ -133,6 +133,8 @@ public class Query {
      */
     public static String populateMatcherClause(Matcher matcher, String indexFieldName, String value, Map<String, String> params) throws ValidationException {
         String matcherClause = matcher.clause();
+        // Quotes and backslashes need to be escaped for the matcher to correctly perform the substitution
+        String escapedValue = java.util.regex.Matcher.quoteReplacement(Json.jsonStringEscape(value));
         for (String variable : matcher.variables().keySet()) {
             Pattern pattern = matcher.variables().get(variable);
             switch (variable) {
@@ -140,7 +142,7 @@ public class Query {
                     matcherClause = pattern.matcher(matcherClause).replaceAll(indexFieldName);
                     break;
                 case "value":
-                    matcherClause = pattern.matcher(matcherClause).replaceAll(value);
+                    matcherClause = pattern.matcher(matcherClause).replaceAll(escapedValue);
                     break;
                 default:
                     java.util.regex.Matcher m = Patterns.VARIABLE_PARAMS.matcher(variable);

--- a/src/test/java/io/zentity/resolution/JobTest.java
+++ b/src/test/java/io/zentity/resolution/JobTest.java
@@ -110,6 +110,29 @@ public class JobTest {
     }
 
     /**
+     * Sometimes the value extracted from the document contains quotations or backslashes that need to be escaped
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testPopulateMatcherClauseQuoteJsonString() throws Exception {
+        String matcherJson = "{\n" +
+                "  \"clause\": {\n" +
+                "    \"match\": {\n" +
+                "      \"{{ field }}\": \"{{ value }}\"\n" +
+                "    }" +
+                "  }\n" +
+                "}";
+        String nameAlias = "The \"One\"";
+        Matcher matcher = new Matcher("matcher_alias", matcherJson);
+        TreeMap<String, String> params = new TreeMap<>();
+        params.put("foo", "bar");
+        String matcherClause = Query.populateMatcherClause(matcher, "field_alias", nameAlias, params);
+        String expected = "{\"match\":{\"field_alias\":\"The \\\"One\\\"\"}}";
+        Assert.assertEquals(expected, matcherClause);
+    }
+
+    /**
      * Populate the clause of a matcher by substituting the {{ field }} and {{ value }} variables,
      * but don't include {{ field }} and expect an exception to be raised.
      *


### PR DESCRIPTION
When performing entity resolution, ES documents may sometimes contain string fields that contain quotes or backslashes. 

These will then be picked up by zentity and substituted into the template [here](https://github.com/zentity-io/zentity/blob/main/src/main/java/io/zentity/resolution/Query.java#L143), which causes it to escape out of the query.

At the worst case, a specially crafted document can cause zentity to perform arbitrary queries - but I haven't gotten around to making a POC for this 😄. We discovered this by seeing `com.fasterxml.jackson.core.JsonParseException` when performing certain queries.